### PR TITLE
[codex] Update footer attribution

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -269,7 +269,10 @@ export default function App() {
         <div>MIT License · Built by <a href="https://alexanderqchen.com" target="_blank" rel="noreferrer"
             style={{ color: '#555', textDecoration: 'none' }}
             onMouseEnter={e => (e.currentTarget.style.color = '#aaa')}
-            onMouseLeave={e => (e.currentTarget.style.color = '#555')}>Alexander Chen</a></div>
+            onMouseLeave={e => (e.currentTarget.style.color = '#555')}>Alexander Chen</a> & <a href="https://www.experimental.software/" target="_blank" rel="noreferrer"
+            style={{ color: '#555', textDecoration: 'none' }}
+            onMouseEnter={e => (e.currentTarget.style.color = '#aaa')}
+            onMouseLeave={e => (e.currentTarget.style.color = '#555')}>Experimental Software</a></div>
         <div style={{ marginTop: 8, display: 'flex', justifyContent: 'center', gap: 16 }}>
           <a href="https://github.com/alexanderqchen/orb-ui" target="_blank" rel="noreferrer"
             style={{ color: '#555', textDecoration: 'none' }}


### PR DESCRIPTION
## Summary

Updates the demo footer attribution so Alexander Chen remains linked to the personal site while Experimental Software is linked separately.

## Impact

Visitors can now follow each credited name to the correct destination from the footer.

## Validation

- Reloaded the running Vite dev server and verified both footer links render with the expected hrefs.
- Ran `npm run build` in `demo/` successfully. Vite reported the existing large chunk warning.