### PR TITLE
[codex] Replace live demo providers with simulation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>orb-ui — React Components for Voice AI | Vapi & ElevenLabs</title>
+    <title>orb-ui - React Components for Voice AI</title>
     <meta
       name="description"
-      content="Beautiful voice AI UI components for React. Drop-in Orb component with built-in adapters for Vapi and ElevenLabs. Open source, themeable, reactive to audio volume."
+      content="Beautiful voice AI UI components for React. Drop-in Orb component with controlled state, provider adapters, themes, and audio-reactive volume."
     />
     <link rel="canonical" href="https://orb-ui.com" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://orb-ui.com" />
-    <meta property="og:title" content="orb-ui — Beautiful Voice AI in Minutes, Not Days" />
+    <meta property="og:title" content="orb-ui - Beautiful Voice AI in Minutes, Not Days" />
     <meta
       property="og:description"
-      content="The simplest voice AI component library for React. Works with Vapi and ElevenLabs. Open source."
+      content="A small React orb that responds to conversation state and audio volume."
     />
     <meta property="og:image" content="https://orb-ui.com/og-image.jpg" />
     <meta property="og:image:width" content="1200" />
@@ -24,17 +24,17 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="orb-ui — Beautiful Voice AI in Minutes, Not Days" />
+    <meta name="twitter:title" content="orb-ui - Beautiful Voice AI in Minutes, Not Days" />
     <meta
       name="twitter:description"
-      content="The simplest voice AI component library for React. Works with Vapi and ElevenLabs. Open source."
+      content="A small React orb that responds to conversation state and audio volume."
     />
     <meta name="twitter:image" content="https://orb-ui.com/og-image.jpg" />
 
     <!-- Additional SEO -->
     <meta
       name="keywords"
-      content="voice AI, React, component library, Vapi, ElevenLabs, voice agent, UI, orb, speech, open source"
+      content="voice AI, React, component library, voice agent, UI, orb, speech, open source"
     />
     <meta name="author" content="Alexander Chen" />
     <meta name="robots" content="index, follow" />
@@ -46,7 +46,7 @@
         "@context": "https://schema.org",
         "@type": "SoftwareSourceCode",
         "name": "orb-ui",
-        "description": "React component library for voice AI agent UIs. Works with Vapi and ElevenLabs.",
+        "description": "React component library for voice AI agent UIs with controlled state, adapters, themes, and audio-reactive volume.",
         "url": "https://orb-ui.com",
         "codeRepository": "https://github.com/alexanderqchen/orb-ui",
         "programmingLanguage": "TypeScript",

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>orb-ui - React Components for Voice AI</title>
+    <title>orb-ui — React Components for Voice AI | Vapi & ElevenLabs</title>
     <meta
       name="description"
-      content="Beautiful voice AI UI components for React. Drop-in Orb component with controlled state, provider adapters, themes, and audio-reactive volume."
+      content="Beautiful voice AI UI components for React. Drop-in Orb component with built-in adapters for Vapi and ElevenLabs. Open source, themeable, reactive to audio volume."
     />
     <link rel="canonical" href="https://orb-ui.com" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://orb-ui.com" />
-    <meta property="og:title" content="orb-ui - Beautiful Voice AI in Minutes, Not Days" />
+    <meta property="og:title" content="orb-ui — Beautiful Voice AI in Minutes, Not Days" />
     <meta
       property="og:description"
-      content="A small React orb that responds to conversation state and audio volume."
+      content="The simplest voice AI component library for React. Works with Vapi and ElevenLabs. Open source."
     />
     <meta property="og:image" content="https://orb-ui.com/og-image.jpg" />
     <meta property="og:image:width" content="1200" />
@@ -24,17 +24,17 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="orb-ui - Beautiful Voice AI in Minutes, Not Days" />
+    <meta name="twitter:title" content="orb-ui — Beautiful Voice AI in Minutes, Not Days" />
     <meta
       name="twitter:description"
-      content="A small React orb that responds to conversation state and audio volume."
+      content="The simplest voice AI component library for React. Works with Vapi and ElevenLabs. Open source."
     />
     <meta name="twitter:image" content="https://orb-ui.com/og-image.jpg" />
 
     <!-- Additional SEO -->
     <meta
       name="keywords"
-      content="voice AI, React, component library, voice agent, UI, orb, speech, open source"
+      content="voice AI, React, component library, Vapi, ElevenLabs, voice agent, UI, orb, speech, open source"
     />
     <meta name="author" content="Alexander Chen" />
     <meta name="robots" content="index, follow" />
@@ -46,7 +46,7 @@
         "@context": "https://schema.org",
         "@type": "SoftwareSourceCode",
         "name": "orb-ui",
-        "description": "React component library for voice AI agent UIs with controlled state, adapters, themes, and audio-reactive volume.",
+        "description": "React component library for voice AI agent UIs. Works with Vapi and ElevenLabs.",
         "url": "https://orb-ui.com",
         "codeRepository": "https://github.com/alexanderqchen/orb-ui",
         "programmingLanguage": "TypeScript",

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,8 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@elevenlabs/client": "^0.15.0",
-    "@vapi-ai/web": "^2.5.2",
     "orb-ui": "workspace:*"
   },
   "devDependencies": {

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,56 +1,31 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
-import * as VapiModule from '@vapi-ai/web'
-import { Conversation } from '@elevenlabs/client'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
 import { Orb } from 'orb-ui'
-import { createVapiAdapter, createElevenLabsAdapter } from 'orb-ui/adapters'
 import type { OrbState, OrbTheme } from 'orb-ui'
 
-// ─── Env vars ─────────────────────────────────────────────────────────────────
-const VAPI_PUBLIC_KEY = import.meta.env.VITE_VAPI_PUBLIC_KEY as string
-const VAPI_ASSISTANT_ID = import.meta.env.VITE_VAPI_ASSISTANT_ID as string
-const EL_AGENT_ID = import.meta.env.VITE_EL_AGENT_ID as string
-
-// ─── Constants ────────────────────────────────────────────────────────────────
+// Constants
 const STATES: OrbState[] = ['idle', 'connecting', 'listening', 'speaking', 'error']
 const THEMES: OrbTheme[] = ['circle', 'bars', 'debug']
 
-type VapiClient = Parameters<typeof createVapiAdapter>[0]
-type VapiConstructor = new (publicKey: string) => VapiClient
+type DemoMode = 'simulation' | 'sandbox'
+type CodeTab = 'vapi' | 'elevenlabs' | 'adapter' | 'controlled'
 
-function getVapiConstructor(): VapiConstructor | null {
-  const maybeDefault = (VapiModule as { default?: unknown }).default ?? VapiModule
-  const maybeNestedDefault = (maybeDefault as { default?: unknown }).default ?? maybeDefault
-
-  if (typeof maybeNestedDefault !== 'function') {
-    console.error('[orb-ui demo] @vapi-ai/web did not export a Vapi constructor')
-    return null
-  }
-
-  return maybeNestedDefault as VapiConstructor
+interface SimulationStep {
+  state: OrbState
+  duration: number
 }
 
-function createVapiClient(): VapiClient | null {
-  if (!VAPI_PUBLIC_KEY) return null
+const SIMULATION_STEPS: SimulationStep[] = [
+  { state: 'idle', duration: 1300 },
+  { state: 'connecting', duration: 1000 },
+  { state: 'speaking', duration: 3400 },
+  { state: 'listening', duration: 2600 },
+]
 
-  const Vapi = getVapiConstructor()
-  if (!Vapi) return null
+const SIMULATION_DURATION = SIMULATION_STEPS.reduce((total, step) => total + step.duration, 0)
+const MONOSPACE_FONT =
+  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
 
-  try {
-    return new Vapi(VAPI_PUBLIC_KEY)
-  } catch (error) {
-    console.error('[orb-ui demo] Failed to create Vapi client', error)
-    return null
-  }
-}
-
-// ─── Singleton adapters ───────────────────────────────────────────────────────
-const vapi = createVapiClient()
-const vapiAdapter = vapi ? createVapiAdapter(vapi, { assistantId: VAPI_ASSISTANT_ID }) : undefined
-const elAdapter = EL_AGENT_ID
-  ? createElevenLabsAdapter(Conversation, { agentId: EL_AGENT_ID })
-  : undefined
-
-// ─── Code snippets ────────────────────────────────────────────────────────────
 const VAPI_CODE = `import Vapi from "@vapi-ai/web"
 import { Orb } from "orb-ui"
 import { createVapiAdapter } from "orb-ui/adapters"
@@ -60,11 +35,11 @@ const adapter = createVapiAdapter(vapi, {
   assistantId: "your-assistant-id"
 })
 
-function App() {
+export function VoiceOrb() {
   return <Orb adapter={adapter} theme="circle" />
 }`
 
-const EL_CODE = `import { Conversation } from "@elevenlabs/client"
+const ELEVENLABS_CODE = `import { Conversation } from "@elevenlabs/client"
 import { Orb } from "orb-ui"
 import { createElevenLabsAdapter } from "orb-ui/adapters"
 
@@ -72,70 +47,247 @@ const adapter = createElevenLabsAdapter(Conversation, {
   agentId: "your-agent-id"
 })
 
-function App() {
+export function VoiceOrb() {
   return <Orb adapter={adapter} theme="circle" />
 }`
 
-const CUSTOM_CODE = `import { Orb } from "orb-ui"
-import { useState } from "react"
+const ADAPTER_CODE = `import { Orb } from "orb-ui"
+import type { OrbAdapter } from "orb-ui"
 
-function App() {
-  const [state, setState] = useState("idle")
-  const [volume, setVolume] = useState(0)
+const adapter: OrbAdapter = {
+  subscribe({ onStateChange, onVolumeChange }) {
+    voiceClient.on("state", onStateChange)
+    voiceClient.on("volume", onVolumeChange)
 
-  // Connect to any voice provider — just update state and volume
-  return <Orb state={state} volume={volume} theme="circle" />
+    return () => {
+      voiceClient.off("state", onStateChange)
+      voiceClient.off("volume", onVolumeChange)
+    }
+  },
+  start: () => voiceClient.start(),
+  stop: () => voiceClient.stop()
+}
+
+export function VoiceOrb() {
+  return <Orb adapter={adapter} theme="circle" />
 }`
 
-// ─── Shared button style helper ──────────────────────────────────────────────
-function btnStyle(selected: boolean, disabled = false): React.CSSProperties {
+const CONTROLLED_CODE = `import { useEffect, useState } from "react"
+import { Orb } from "orb-ui"
+import type { OrbState } from "orb-ui"
+
+export function PreviewOrb() {
+  const [signal, setSignal] = useState({
+    state: "listening" as OrbState,
+    volume: 0
+  })
+
+  useEffect(() => {
+    let frame = 0
+
+    function tick() {
+      const t = performance.now() / 1000
+      const state = Math.floor(t / 3) % 2 === 0 ? "speaking" : "listening"
+      const volume = Math.max(0, Math.min(1, 0.45 + Math.sin(t * 9) * 0.3))
+
+      setSignal({ state, volume })
+      frame = requestAnimationFrame(tick)
+    }
+
+    frame = requestAnimationFrame(tick)
+
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  return <Orb state={signal.state} volume={signal.volume} theme="circle" />
+}`
+
+function clamp(value: number, min = 0, max = 1) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function envelope(elapsed: number, duration: number) {
+  const fadeIn = clamp(elapsed / 320)
+  const fadeOut = clamp((duration - elapsed) / 360)
+  return Math.min(fadeIn, fadeOut)
+}
+
+function nowMs() {
+  return typeof performance === 'undefined' ? Date.now() : performance.now()
+}
+
+function simulatedVolume(step: SimulationStep, elapsed: number) {
+  if (step.state !== 'listening' && step.state !== 'speaking') return 0
+
+  const t = elapsed / 1000
+  const shape = envelope(elapsed, step.duration)
+
+  if (step.state === 'listening') {
+    const voice =
+      0.22 + Math.sin(t * 7.7) * 0.1 + Math.sin(t * 13.1 + 0.8) * 0.07 + Math.sin(t * 21.2) * 0.04
+
+    return clamp(voice * shape, 0.02, 0.58)
+  }
+
+  const voice =
+    0.5 + Math.sin(t * 8.4) * 0.19 + Math.sin(t * 15.6 + 1.2) * 0.13 + Math.sin(t * 25.2) * 0.07
+
+  return clamp(voice * shape, 0.05, 0.95)
+}
+
+function getSimulationFrame(startedAt: number, now: number) {
+  let elapsed = (now - startedAt) % SIMULATION_DURATION
+
+  for (const step of SIMULATION_STEPS) {
+    if (elapsed <= step.duration) {
+      return {
+        state: step.state,
+        volume: simulatedVolume(step, elapsed),
+      }
+    }
+
+    elapsed -= step.duration
+  }
+
+  return {
+    state: 'idle' as OrbState,
+    volume: 0,
+  }
+}
+
+function useConversationSimulation() {
+  const [startedAt] = useState(() => nowMs())
+  const [frame, setFrame] = useState(() => getSimulationFrame(nowMs(), nowMs()))
+
+  useEffect(() => {
+    let raf = 0
+
+    const updateFrame = () => {
+      setFrame(getSimulationFrame(startedAt, nowMs()))
+      raf = requestAnimationFrame(updateFrame)
+    }
+
+    updateFrame()
+
+    return () => cancelAnimationFrame(raf)
+  }, [startedAt])
+
+  return frame
+}
+
+function btnStyle(selected: boolean, disabled = false): CSSProperties {
   return {
     padding: '6px 16px',
     fontSize: 12,
     background: selected ? '#fff' : '#111',
-    color: selected ? '#000' : disabled ? '#444' : '#666',
-    border: `1px solid ${selected ? '#fff' : '#222'}`,
+    color: selected ? '#000' : disabled ? '#444' : '#777',
+    border: `1px solid ${selected ? '#fff' : '#242424'}`,
     borderRadius: 4,
     cursor: disabled ? 'not-allowed' : 'pointer',
     opacity: disabled ? 0.35 : 1,
     fontFamily: 'inherit',
+    whiteSpace: 'nowrap',
   }
 }
 
-// ─── App ──────────────────────────────────────────────────────────────────────
+const labelStyle: CSSProperties = {
+  fontSize: 11,
+  color: '#555',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+}
+
+const volumeTextStyle: CSSProperties = {
+  display: 'inline-block',
+  width: '100%',
+  minWidth: '4ch',
+  textAlign: 'right',
+  fontFamily: MONOSPACE_FONT,
+  fontVariantNumeric: 'tabular-nums',
+}
+
+const statusStripStyle: CSSProperties = {
+  marginTop: 16,
+  display: 'grid',
+  gridTemplateColumns: '82px 8px 82px 8px 44px',
+  alignItems: 'center',
+  justifyItems: 'center',
+  gap: 6,
+  width: 248,
+  color: '#777',
+  fontSize: 13,
+  whiteSpace: 'nowrap',
+}
+
+const statusCellStyle: CSSProperties = {
+  width: '100%',
+  textAlign: 'center',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+}
+
+const statusSeparatorStyle: CSSProperties = {
+  color: '#333',
+  textAlign: 'center',
+}
+
+function codeForTab(tab: CodeTab) {
+  switch (tab) {
+    case 'elevenlabs':
+      return ELEVENLABS_CODE
+    case 'adapter':
+      return ADAPTER_CODE
+    case 'controlled':
+      return CONTROLLED_CODE
+    case 'vapi':
+    default:
+      return VAPI_CODE
+  }
+}
+
+// App
 export default function App() {
+  const simulation = useConversationSimulation()
   const [theme, setTheme] = useState<OrbTheme>('circle')
+  const [mode, setMode] = useState<DemoMode>('simulation')
   const [sandboxState, setSandboxState] = useState<OrbState>('idle')
   const [sandboxVolume, setSandboxVolume] = useState(0)
-  const [provider, setProvider] = useState<'vapi' | 'elevenlabs' | 'sandbox'>(() =>
-    vapiAdapter ? 'vapi' : elAdapter ? 'elevenlabs' : 'sandbox',
-  )
   const [copied, setCopied] = useState(false)
-  const [codeTab, setCodeTab] = useState<'vapi' | 'elevenlabs' | 'custom'>('vapi')
+  const [codeTab, setCodeTab] = useState<CodeTab>('vapi')
 
-  const adapter =
-    provider === 'vapi' ? vapiAdapter : provider === 'elevenlabs' ? elAdapter : undefined
-
-  // Stop the previous adapter's call when switching providers
-  const prevAdapterRef = useRef(adapter)
-  useEffect(() => {
-    const prev = prevAdapterRef.current
-    if (prev && prev !== adapter) {
-      prev.stop?.()
+  const activeOrb = useMemo(() => {
+    if (mode === 'sandbox') {
+      return {
+        mode: 'Sandbox',
+        state: sandboxState,
+        volume: sandboxVolume,
+      }
     }
-    prevAdapterRef.current = adapter
-  }, [adapter])
 
-  const orbProps = adapter ? { adapter } : { state: sandboxState, volume: sandboxVolume }
+    return {
+      mode: 'Simulation',
+      state: simulation.state,
+      volume: simulation.volume,
+    }
+  }, [mode, sandboxState, sandboxVolume, simulation])
 
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText('npm install orb-ui')
     setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
+    window.setTimeout(() => setCopied(false), 1500)
   }, [])
 
-  const vapiMissing = !VAPI_PUBLIC_KEY || !VAPI_ASSISTANT_ID || !vapiAdapter
-  const elMissing = !EL_AGENT_ID || !elAdapter
+  const handleSandboxState = useCallback((nextState: OrbState) => {
+    setSandboxState(nextState)
+
+    if (nextState === 'listening') {
+      setSandboxVolume((volume) => (volume === 0 ? 0.35 : volume))
+    } else if (nextState === 'speaking') {
+      setSandboxVolume((volume) => (volume === 0 ? 0.65 : volume))
+    } else {
+      setSandboxVolume(0)
+    }
+  }, [])
 
   return (
     <div
@@ -146,7 +298,6 @@ export default function App() {
         fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
       }}
     >
-      {/* ── Nav ─────────────────────────────────────────────────────────── */}
       <nav
         style={{
           position: 'sticky',
@@ -158,6 +309,7 @@ export default function App() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
+          gap: 24,
         }}
       >
         <span style={{ fontWeight: 700, fontSize: 18, color: '#fff' }}>orb-ui</span>
@@ -185,9 +337,8 @@ export default function App() {
         </div>
       </nav>
 
-      {/* ── Hero ────────────────────────────────────────────────────────── */}
       <section
-        style={{ padding: '80px 32px 48px', textAlign: 'center', maxWidth: 640, margin: '0 auto' }}
+        style={{ padding: '80px 32px 48px', textAlign: 'center', maxWidth: 680, margin: '0 auto' }}
       >
         <h1
           style={{
@@ -201,8 +352,8 @@ export default function App() {
           Beautiful voice AI in minutes, not days.
         </h1>
         <p style={{ fontSize: 16, color: '#888', marginTop: 16, lineHeight: 1.6 }}>
-          The simplest voice AI component library for React. Works with Vapi and ElevenLabs. No
-          config, no boilerplate — just drop it in.
+          A small React orb that responds to conversation state and volume. Use an adapter in
+          production, or control it directly for previews, mocks, and docs.
         </p>
         <div
           style={{
@@ -214,63 +365,60 @@ export default function App() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
+            gap: 16,
             fontFamily: 'monospace',
             fontSize: 14,
             color: '#aaa',
           }}
         >
-          <span>npm install orb-ui</span>
+          <span style={{ overflowWrap: 'anywhere' }}>npm install orb-ui</span>
           <button
             onClick={handleCopy}
             style={{
               background: 'none',
               border: 'none',
               cursor: 'pointer',
-              color: '#555',
+              color: '#777',
               fontSize: 13,
               fontFamily: 'inherit',
               padding: '2px 6px',
             }}
             onMouseEnter={(e) => (e.currentTarget.style.color = '#fff')}
-            onMouseLeave={(e) => (e.currentTarget.style.color = '#555')}
+            onMouseLeave={(e) => (e.currentTarget.style.color = '#777')}
           >
-            {copied ? 'Copied!' : '📋'}
+            {copied ? 'Copied' : 'Copy'}
           </button>
         </div>
       </section>
 
-      {/* ── Demo ────────────────────────────────────────────────────────── */}
-      <section style={{ padding: '48px 32px', maxWidth: 640, margin: '0 auto' }}>
-        <div
-          style={{
-            fontSize: 11,
-            color: '#555',
-            letterSpacing: '0.1em',
-            textAlign: 'center',
-            marginBottom: 32,
-          }}
-        >
-          LIVE DEMO
-        </div>
+      <section style={{ padding: '48px 32px', maxWidth: 680, margin: '0 auto' }}>
+        <div style={{ ...labelStyle, textAlign: 'center', marginBottom: 32 }}>Simulated demo</div>
 
-        {/* Orb display */}
         <div
           style={{
+            width: 300,
+            minHeight: 300,
+            margin: '0 auto',
             display: 'flex',
-            justifyContent: 'center',
+            flexDirection: 'column',
             alignItems: 'center',
-            minHeight: 320,
+            justifyContent: 'center',
           }}
         >
-          <Orb theme={theme} size={280} {...orbProps} />
+          <Orb theme={theme} size={280} state={activeOrb.state} volume={activeOrb.volume} />
+
+          <div style={statusStripStyle}>
+            <span style={statusCellStyle}>{activeOrb.mode}</span>
+            <span style={statusSeparatorStyle}>/</span>
+            <span style={statusCellStyle}>{activeOrb.state}</span>
+            <span style={statusSeparatorStyle}>/</span>
+            <span style={volumeTextStyle}>{activeOrb.volume.toFixed(2)}</span>
+          </div>
         </div>
 
-        {/* Theme switcher */}
         <div style={{ marginTop: 32, textAlign: 'center' }}>
-          <div style={{ fontSize: 11, color: '#555', letterSpacing: '0.1em', marginBottom: 8 }}>
-            THEME
-          </div>
-          <div style={{ display: 'flex', justifyContent: 'center', gap: 8 }}>
+          <div style={{ ...labelStyle, marginBottom: 8 }}>Theme</div>
+          <div style={{ display: 'flex', justifyContent: 'center', gap: 8, flexWrap: 'wrap' }}>
             {THEMES.map((t) => (
               <button key={t} onClick={() => setTheme(t)} style={btnStyle(theme === t)}>
                 {t}
@@ -279,53 +427,40 @@ export default function App() {
           </div>
         </div>
 
-        {/* Provider switcher */}
         <div style={{ marginTop: 16, textAlign: 'center' }}>
-          <div style={{ fontSize: 11, color: '#555', letterSpacing: '0.1em', marginBottom: 8 }}>
-            PROVIDER
-          </div>
-          <div style={{ display: 'flex', justifyContent: 'center', gap: 8 }}>
+          <div style={{ ...labelStyle, marginBottom: 8 }}>Mode</div>
+          <div style={{ display: 'flex', justifyContent: 'center', gap: 8, flexWrap: 'wrap' }}>
             {(
               [
-                { id: 'vapi', label: 'Vapi 🎙', disabled: vapiMissing },
-                { id: 'elevenlabs', label: 'ElevenLabs ⚡', disabled: elMissing },
-                { id: 'sandbox', label: 'Sandbox 🧪', disabled: false },
+                { id: 'simulation', label: 'Simulation' },
+                { id: 'sandbox', label: 'Sandbox' },
               ] as const
-            ).map(({ id, label, disabled }) => (
-              <button
-                key={id}
-                onClick={() => {
-                  if (!disabled) setProvider(id)
-                }}
-                disabled={disabled}
-                style={btnStyle(provider === id, disabled)}
-              >
+            ).map(({ id, label }) => (
+              <button key={id} onClick={() => setMode(id)} style={btnStyle(mode === id)}>
                 {label}
               </button>
             ))}
           </div>
         </div>
 
-        {/* Sandbox controls */}
-        {provider === 'sandbox' && (
+        {mode === 'sandbox' && (
           <div
             style={{
-              marginTop: 24,
+              margin: '24px auto 0',
+              maxWidth: 420,
               padding: '20px 24px',
               background: '#111',
               border: '1px solid #1e1e1e',
               borderRadius: 8,
             }}
           >
-            <div style={{ fontSize: 11, color: '#555', letterSpacing: '0.1em', marginBottom: 16 }}>
-              PLAYGROUND
-            </div>
+            <div style={{ ...labelStyle, marginBottom: 16 }}>Playground</div>
 
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 20 }}>
               {STATES.map((s) => (
                 <button
                   key={s}
-                  onClick={() => setSandboxState(s)}
+                  onClick={() => handleSandboxState(s)}
                   style={btnStyle(sandboxState === s)}
                 >
                   {s}
@@ -336,14 +471,12 @@ export default function App() {
             <div>
               <label
                 style={{
-                  fontSize: 11,
-                  color: '#555',
-                  letterSpacing: '0.1em',
+                  ...labelStyle,
                   display: 'block',
                   marginBottom: 8,
                 }}
               >
-                VOLUME — {sandboxVolume.toFixed(2)}
+                Volume / {sandboxVolume.toFixed(2)}
               </label>
               <input
                 type="range"
@@ -352,35 +485,17 @@ export default function App() {
                 step={0.01}
                 value={sandboxVolume}
                 onChange={(e) => setSandboxVolume(parseFloat(e.target.value))}
-                style={{ width: '100%', accentColor: '#4f9eff' }}
+                style={{ width: '100%', accentColor: '#d9d9d9' }}
               />
             </div>
           </div>
         )}
-
-        {/* Live provider hint */}
-        {provider !== 'sandbox' && (
-          <div style={{ marginTop: 16, fontSize: 13, color: '#555', textAlign: 'center' }}>
-            Click the orb to start or stop a live conversation.
-          </div>
-        )}
       </section>
 
-      {/* ── Code ────────────────────────────────────────────────────────── */}
-      <section style={{ padding: '48px 32px', maxWidth: 640, margin: '0 auto' }}>
-        <div
-          style={{
-            fontSize: 11,
-            color: '#555',
-            letterSpacing: '0.1em',
-            marginBottom: 24,
-            textAlign: 'center',
-          }}
-        >
-          QUICK START
-        </div>
+      <section style={{ padding: '48px 32px', maxWidth: 680, margin: '0 auto' }}>
+        <div style={{ ...labelStyle, marginBottom: 24, textAlign: 'center' }}>Quick start</div>
 
-        <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}>
           <button onClick={() => setCodeTab('vapi')} style={btnStyle(codeTab === 'vapi')}>
             Vapi
           </button>
@@ -390,8 +505,14 @@ export default function App() {
           >
             ElevenLabs
           </button>
-          <button onClick={() => setCodeTab('custom')} style={btnStyle(codeTab === 'custom')}>
-            Custom
+          <button onClick={() => setCodeTab('adapter')} style={btnStyle(codeTab === 'adapter')}>
+            Adapter
+          </button>
+          <button
+            onClick={() => setCodeTab('controlled')}
+            style={btnStyle(codeTab === 'controlled')}
+          >
+            Controlled
           </button>
         </div>
 
@@ -410,11 +531,10 @@ export default function App() {
             margin: 0,
           }}
         >
-          {codeTab === 'vapi' ? VAPI_CODE : codeTab === 'elevenlabs' ? EL_CODE : CUSTOM_CODE}
+          {codeForTab(codeTab)}
         </pre>
       </section>
 
-      {/* ── Footer ──────────────────────────────────────────────────────── */}
       <footer
         style={{
           padding: 32,
@@ -426,7 +546,7 @@ export default function App() {
         }}
       >
         <div>
-          MIT License · Built by{' '}
+          MIT License - Built by{' '}
           <a
             href="https://alexanderqchen.com"
             target="_blank"
@@ -437,7 +557,7 @@ export default function App() {
           >
             Alexander Chen
           </a>{' '}
-          &{' '}
+          and{' '}
           <a
             href="https://www.experimental.software/"
             target="_blank"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,12 +55,6 @@ importers:
 
   demo:
     dependencies:
-      '@elevenlabs/client':
-        specifier: ^0.15.0
-        version: 0.15.2(@types/dom-mediacapture-record@1.0.22)
-      '@vapi-ai/web':
-        specifier: ^2.5.2
-        version: 2.5.2
       orb-ui:
         specifier: workspace:*
         version: link:..
@@ -94,12 +88,6 @@ packages:
         integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==,
       }
     engines: { node: '>=6.9.0' }
-
-  '@bufbuild/protobuf@1.10.1':
-    resolution:
-      {
-        integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==,
-      }
 
   '@changesets/apply-release-plan@7.1.1':
     resolution:
@@ -208,25 +196,6 @@ packages:
     resolution:
       {
         integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
-      }
-
-  '@daily-co/daily-js@0.85.0':
-    resolution:
-      {
-        integrity: sha512-lpl111ZWNTUWDnwYcPuNi9PGJPbLCeCw6LzmEY40nG0hv1jg5JLVW8Rq3Cj/+lOCP6W6h4PXm211ss0FFnxITQ==,
-      }
-    engines: { node: '>=10.0.0' }
-
-  '@elevenlabs/client@0.15.2':
-    resolution:
-      {
-        integrity: sha512-IKEs0OUHol9ZQ/gKBh5ThN5udRp6bnU70DxyRxprWop3zA8oYUdBa+LE+2tlWho9A4UKubD5UjvjCBJLh2cDVw==,
-      }
-
-  '@elevenlabs/types@0.6.1':
-    resolution:
-      {
-        integrity: sha512-SNFrKWw5w/JHy9QGt3WWBj0kc71diPRuXHc/7/hdr46ghYz8mTPlFZJBmSPGwXQAfS29jxYXojEmBfKKfgoPCQ==,
       }
 
   '@emnapi/core@1.10.0':
@@ -386,18 +355,6 @@ packages:
     resolution:
       {
         integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
-      }
-
-  '@livekit/mutex@1.1.1':
-    resolution:
-      {
-        integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==,
-      }
-
-  '@livekit/protocol@1.45.8':
-    resolution:
-      {
-        integrity: sha512-Q+l57E7w/xxOBFVWzdX5rkAZO7ffyF+rlDzNUYq2SU114+5aTyCq+PK4unaEVDNd4952Af7wteKr3sOgasGuaA==,
       }
 
   '@manypkg/find-root@1.1.0':
@@ -819,48 +776,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sentry-internal/browser-utils@8.55.2':
-    resolution:
-      {
-        integrity: sha512-GnKod+gL/Y+1FUM/RGV8q6le1CoyiGbT40MitEK7eVwWe+bfTRq1gN7ioupyHFMUg1RlQkDQ4/sENmio/uow5A==,
-      }
-    engines: { node: '>=14.18' }
-
-  '@sentry-internal/feedback@8.55.2':
-    resolution:
-      {
-        integrity: sha512-XQy//NWbL0mLLM5w8wNDWMNpXz39VUyW2397dUrH8++kR63WhUVAvTOtL0o0GMVadSAzl1b08oHP9zSUNFQwcg==,
-      }
-    engines: { node: '>=14.18' }
-
-  '@sentry-internal/replay-canvas@8.55.2':
-    resolution:
-      {
-        integrity: sha512-P/jGiuR7dRLG9IzD/463fLgiibyYceauav/9prRG0ZxJm1AtuO02OKball2Fs3bbzdzwHCTlcsUuL2ivDF4b5A==,
-      }
-    engines: { node: '>=14.18' }
-
-  '@sentry-internal/replay@8.55.2':
-    resolution:
-      {
-        integrity: sha512-+W43Z697EVe/OgpGW07B773sa8xO1UbpnW0Cr+E+3FMDb6ZbXlaBUoagPTUkkQPdwBe35SDh6r8y2M3EOPGbxg==,
-      }
-    engines: { node: '>=14.18' }
-
-  '@sentry/browser@8.55.2':
-    resolution:
-      {
-        integrity: sha512-xHuPIEKhx9zw5quWvv4YgZprnwoVMCfxIhmOIf6KJ9iizyUHeUDcKpLS59xERroqwX4RpvK+l/27AZu4zfZlzQ==,
-      }
-    engines: { node: '>=14.18' }
-
-  '@sentry/core@8.55.2':
-    resolution:
-      {
-        integrity: sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==,
-      }
-    engines: { node: '>=14.18' }
-
   '@standard-schema/spec@1.1.0':
     resolution:
       {
@@ -883,12 +798,6 @@ packages:
     resolution:
       {
         integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
-      }
-
-  '@types/dom-mediacapture-record@1.0.22':
-    resolution:
-      {
-        integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==,
       }
 
   '@types/esrecurse@4.3.1':
@@ -1029,13 +938,6 @@ packages:
         integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  '@vapi-ai/web@2.5.2':
-    resolution:
-      {
-        integrity: sha512-mT4DjApi0/0+EK77h2xOLq3qVBa7rv3JNQ+gFWuhFE4YdGYxI51+fn8bQI9N535+zU/Z4jFKXotdBHQJ3filHA==,
-      }
-    engines: { node: '>=18.0.0' }
 
   '@vitejs/plugin-react@6.0.2':
     resolution:
@@ -1197,12 +1099,6 @@ packages:
       }
     engines: { node: '>=4' }
 
-  bowser@2.14.1:
-    resolution:
-      {
-        integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==,
-      }
-
   brace-expansion@5.0.6:
     resolution:
       {
@@ -1284,13 +1180,6 @@ packages:
       {
         integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
       }
-
-  dequal@2.0.3:
-    resolution:
-      {
-        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
-      }
-    engines: { node: '>=6' }
 
   detect-indent@6.1.0:
     resolution:
@@ -1421,13 +1310,6 @@ packages:
         integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
       }
     engines: { node: '>=0.10.0' }
-
-  events@3.3.0:
-    resolution:
-      {
-        integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==,
-      }
-    engines: { node: '>=0.8.x' }
 
   expect-type@1.3.0:
     resolution:
@@ -1664,12 +1546,6 @@ packages:
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
       }
 
-  jose@6.2.3:
-    resolution:
-      {
-        integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==,
-      }
-
   js-tokens@4.0.0:
     resolution:
       {
@@ -1843,14 +1719,6 @@ packages:
       }
     engines: { node: '>= 12.0.0' }
 
-  livekit-client@2.19.0:
-    resolution:
-      {
-        integrity: sha512-aolY1XDAtx0nHKBNm29W9OhzBnSz1CP5kq3phvRhFfi1NbvMXs8tcACjAkZTnIKgihkp+BiJScZZ3tZv0Gz8sA==,
-      }
-    peerDependencies:
-      '@types/dom-mediacapture-record': ^1
-
   local-pkg@1.2.1:
     resolution:
       {
@@ -1877,13 +1745,6 @@ packages:
       {
         integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
       }
-
-  loglevel@1.9.2:
-    resolution:
-      {
-        integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==,
-      }
-    engines: { node: '>= 0.6.0' }
 
   loose-envify@1.4.0:
     resolution:
@@ -2205,12 +2066,6 @@ packages:
         integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
       }
 
-  rxjs@7.8.2:
-    resolution:
-      {
-        integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
-      }
-
   safer-buffer@2.1.2:
     resolution:
       {
@@ -2221,19 +2076,6 @@ packages:
     resolution:
       {
         integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
-      }
-
-  sdp-transform@2.15.0:
-    resolution:
-      {
-        integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==,
-      }
-    hasBin: true
-
-  sdp@3.2.2:
-    resolution:
-      {
-        integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==,
       }
 
   semver@7.8.1:
@@ -2385,12 +2227,6 @@ packages:
         integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
       }
     engines: { node: '>= 0.8.0' }
-
-  typed-emitter@2.1.0:
-    resolution:
-      {
-        integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==,
-      }
 
   typescript-eslint@8.59.4:
     resolution:
@@ -2588,13 +2424,6 @@ packages:
         integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==,
       }
 
-  webrtc-adapter@9.0.5:
-    resolution:
-      {
-        integrity: sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==,
-      }
-    engines: { node: '>=6.0.0', npm: '>=3.10.0' }
-
   which@2.0.2:
     resolution:
       {
@@ -2627,8 +2456,6 @@ packages:
 
 snapshots:
   '@babel/runtime@7.29.2': {}
-
-  '@bufbuild/protobuf@1.10.1': {}
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -2773,23 +2600,6 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@daily-co/daily-js@0.85.0':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@sentry/browser': 8.55.2
-      bowser: 2.14.1
-      dequal: 2.0.3
-      events: 3.3.0
-
-  '@elevenlabs/client@0.15.2(@types/dom-mediacapture-record@1.0.22)':
-    dependencies:
-      '@elevenlabs/types': 0.6.1
-      livekit-client: 2.19.0(@types/dom-mediacapture-record@1.0.22)
-    transitivePeerDependencies:
-      - '@types/dom-mediacapture-record'
-
-  '@elevenlabs/types@0.6.1': {}
-
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -2879,12 +2689,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@livekit/mutex@1.1.1': {}
-
-  '@livekit/protocol@1.45.8':
-    dependencies:
-      '@bufbuild/protobuf': 1.10.1
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -3057,34 +2861,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
-  '@sentry-internal/browser-utils@8.55.2':
-    dependencies:
-      '@sentry/core': 8.55.2
-
-  '@sentry-internal/feedback@8.55.2':
-    dependencies:
-      '@sentry/core': 8.55.2
-
-  '@sentry-internal/replay-canvas@8.55.2':
-    dependencies:
-      '@sentry-internal/replay': 8.55.2
-      '@sentry/core': 8.55.2
-
-  '@sentry-internal/replay@8.55.2':
-    dependencies:
-      '@sentry-internal/browser-utils': 8.55.2
-      '@sentry/core': 8.55.2
-
-  '@sentry/browser@8.55.2':
-    dependencies:
-      '@sentry-internal/browser-utils': 8.55.2
-      '@sentry-internal/feedback': 8.55.2
-      '@sentry-internal/replay': 8.55.2
-      '@sentry-internal/replay-canvas': 8.55.2
-      '@sentry/core': 8.55.2
-
-  '@sentry/core@8.55.2': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.2':
@@ -3098,8 +2874,6 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/deep-eql@4.0.2': {}
-
-  '@types/dom-mediacapture-record@1.0.22': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -3214,11 +2988,6 @@ snapshots:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
-  '@vapi-ai/web@2.5.2':
-    dependencies:
-      '@daily-co/daily-js': 0.85.0
-      events: 3.3.0
-
   '@vitejs/plugin-react@6.0.2(vite@8.0.14)':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -3310,8 +3079,6 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  bowser@2.14.1: {}
-
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
@@ -3345,8 +3112,6 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
-
-  dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
 
@@ -3436,8 +3201,6 @@ snapshots:
       '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
-
-  events@3.3.0: {}
 
   expect-type@1.3.0: {}
 
@@ -3556,8 +3319,6 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jose@6.2.3: {}
-
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -3639,19 +3400,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  livekit-client@2.19.0(@types/dom-mediacapture-record@1.0.22):
-    dependencies:
-      '@livekit/mutex': 1.1.1
-      '@livekit/protocol': 1.45.8
-      '@types/dom-mediacapture-record': 1.0.22
-      events: 3.3.0
-      jose: 6.2.3
-      loglevel: 1.9.2
-      sdp-transform: 2.15.0
-      tslib: 2.8.1
-      typed-emitter: 2.1.0
-      webrtc-adapter: 9.0.5
-
   local-pkg@1.2.1:
     dependencies:
       mlly: 1.8.2
@@ -3667,8 +3415,6 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.startcase@4.4.0: {}
-
-  loglevel@1.9.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -3871,20 +3617,11 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rxjs@7.8.2:
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   safer-buffer@2.1.2: {}
 
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-
-  sdp-transform@2.15.0: {}
-
-  sdp@3.2.2: {}
 
   semver@7.8.1: {}
 
@@ -3940,15 +3677,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  typed-emitter@2.1.0:
-    optionalDependencies:
-      rxjs: 7.8.2
 
   typescript-eslint@8.59.4(eslint@10.4.0)(typescript@5.9.3):
     dependencies:
@@ -4049,10 +3783,6 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   webpack-virtual-modules@0.6.2: {}
-
-  webrtc-adapter@9.0.5:
-    dependencies:
-      sdp: 3.2.2
 
   which@2.0.2:
     dependencies:

--- a/src/themes/bars/BarsTheme.tsx
+++ b/src/themes/bars/BarsTheme.tsx
@@ -176,12 +176,9 @@ export function BarsTheme({
     const animateStatic = () => {
       updateHoverBoost()
       for (let i = 0; i < BAR_COUNT; i++) {
-        const el = barRefs.current[i]
-        if (!el) continue
-        el.style.height = `${minH + hoverBoostRef.current * diamondWeights[i]}px`
-        el.style.background = color
-        el.style.animation = 'none'
+        smoothed.current[i] += (minH - smoothed.current[i]) * 0.16
       }
+      setBars(smoothed.current, color)
       rafRef.current = requestAnimationFrame(animateStatic)
     }
     rafRef.current = requestAnimationFrame(animateStatic)

--- a/src/themes/circle/CircleTheme.tsx
+++ b/src/themes/circle/CircleTheme.tsx
@@ -60,6 +60,8 @@ const LISTEN_GLOW = 0 // no glow during listening — clean edge
 // Output lerp rate — interpolates the adapter's ~10 Hz signal up to 60 fps
 // so the circle animates smoothly rather than snapping every 100 ms.
 const LERP = 0.55
+const SETTLE_RATE = 0.12
+const SETTLE_SCALE_EPSILON = 0.002
 
 export function CircleTheme({ state, volume, size, className, style, onClick }: CircleThemeProps) {
   const circleRef = useRef<HTMLDivElement>(null)
@@ -164,25 +166,70 @@ export function CircleTheme({ state, volume, size, className, style, onClick }: 
         cancelAnimationFrame(rafRef.current)
       }
     } else {
-      // Non-active states: cancel rAF, reset refs, hand off to CSS animations
+      // Non-active states: settle from the current active visual before handing
+      // off to CSS animations. This avoids a visible snap from listening's
+      // compact base scale back to idle.
       cancelAnimationFrame(rafRef.current)
-      currentScaleRef.current = 1
-      currentGlowRef.current = 0
-      currentColorRef.current = hexToRgb(STATE_COLORS[state] ?? STATE_COLORS.idle)
-
-      el.style.transform = ''
-      el.style.boxShadow = 'none'
-      if (glowRef.current) glowRef.current.style.boxShadow = 'none'
       const c = STATE_COLORS[state] ?? STATE_COLORS.idle
-      el.style.background = c
+      const tRgb = hexToRgb(c)
 
-      if (state === 'idle') {
-        el.style.animation = 'orb-circle-idle-pulse 3s ease-in-out infinite alternate'
-      } else if (state === 'connecting') {
-        el.style.animation = 'orb-circle-connecting-pulse 1.5s ease-in-out infinite'
-      } else {
+      const settle = () => {
+        currentScaleRef.current += (1 - currentScaleRef.current) * SETTLE_RATE
+        currentGlowRef.current += (0 - currentGlowRef.current) * SETTLE_RATE
+
+        const [cr, cg, cb] = currentColorRef.current
+        currentColorRef.current = [
+          cr + (tRgb[0] - cr) * SETTLE_RATE,
+          cg + (tRgb[1] - cg) * SETTLE_RATE,
+          cb + (tRgb[2] - cb) * SETTLE_RATE,
+        ]
+        const [r, g, b] = currentColorRef.current.map(Math.round)
+
+        el.style.transform = `scale(${currentScaleRef.current})`
+        el.style.background = `rgb(${r},${g},${b})`
+        el.style.boxShadow = 'none'
         el.style.animation = 'none'
+
+        if (glowRef.current) {
+          glowRef.current.style.transform = `scale(${currentScaleRef.current})`
+          glowRef.current.style.boxShadow = 'none'
+        }
+
+        const scaleDone = Math.abs(currentScaleRef.current - 1) < SETTLE_SCALE_EPSILON
+        const glowDone = currentGlowRef.current < 0.1
+        const colorDone = currentColorRef.current.every(
+          (channel, i) => Math.abs(channel - tRgb[i]) < 1,
+        )
+
+        if (scaleDone && glowDone && colorDone) {
+          currentScaleRef.current = 1
+          currentGlowRef.current = 0
+          currentColorRef.current = tRgb
+
+          el.style.transform = ''
+          el.style.boxShadow = 'none'
+          el.style.background = c
+          if (glowRef.current) {
+            glowRef.current.style.transform = 'scale(1)'
+            glowRef.current.style.boxShadow = 'none'
+          }
+
+          if (state === 'idle') {
+            el.style.animation = 'orb-circle-idle-pulse 3s ease-in-out infinite alternate'
+          } else if (state === 'connecting') {
+            el.style.animation = 'orb-circle-connecting-pulse 1.5s ease-in-out infinite'
+          } else {
+            el.style.animation = 'none'
+          }
+          return
+        }
+
+        rafRef.current = requestAnimationFrame(settle)
       }
+
+      rafRef.current = requestAnimationFrame(settle)
+
+      return () => cancelAnimationFrame(rafRef.current)
     }
   }, [state])
 


### PR DESCRIPTION
## Summary

Replaces the demo site's live Vapi and ElevenLabs flows with a controlled simulated conversation so the orb can be previewed without paid provider credentials.

## What changed

- Removed demo-only Vapi and ElevenLabs SDK dependencies and refreshed the lockfile.
- Reworked the demo to drive `<Orb />` with simulated `idle -> connecting -> speaking -> listening` state and volume values.
- Preserved sandbox controls for manually inspecting orb states and volume.
- Updated quick-start tabs to emphasize existing provider adapters while keeping controlled-mode guidance.
- Updated demo metadata so the hosted site no longer advertises live paid-provider integrations.

## Validation

- `pnpm check`
- Browser verification of the demo layout and simulated state sequence

## Notes

The library adapters remain exported and unchanged; this only removes live provider wiring from the demo site.