### PR TITLE
Standardize docs overview and URL paths

### DIFF
--- a/demo/public/sitemap.xml
+++ b/demo/public/sitemap.xml
@@ -67,31 +67,31 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://orb-ui.com/docs/providers/openai-realtime</loc>
+    <loc>https://orb-ui.com/docs/adapters/openai-realtime</loc>
     <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://orb-ui.com/docs/providers/gemini-live</loc>
+    <loc>https://orb-ui.com/docs/adapters/gemini-live</loc>
     <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://orb-ui.com/docs/resources/voice-agent-platforms</loc>
+    <loc>https://orb-ui.com/docs/guides/voice-agent-platforms</loc>
     <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://orb-ui.com/docs/resources/ai-voice-sales-agents</loc>
+    <loc>https://orb-ui.com/docs/guides/ai-voice-sales-agents</loc>
     <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://orb-ui.com/docs/resources/voice-ai-customer-support</loc>
+    <loc>https://orb-ui.com/docs/guides/voice-ai-customer-support</loc>
     <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -178,7 +178,7 @@ function useConversationSimulation() {
 const NAV_LINKS = [
   { href: '#demo', label: 'Demo' },
   { href: '#quick-start', label: 'Quick Start' },
-  { href: '#providers', label: 'Providers' },
+  { href: '#adapters', label: 'Adapters' },
   { href: '#themes', label: 'Themes' },
   { href: 'https://github.com/alexanderqchen/orb-ui', label: 'GitHub', external: true },
 ] as const
@@ -192,7 +192,7 @@ const SEO_SECTIONS = [
     linkLabel: 'Read the guide',
   },
   {
-    id: 'providers',
+    id: 'adapters',
     title: 'Provider adapters',
     copy: 'Use Vapi and ElevenLabs adapters, or control state and volume yourself.',
     link: '/docs/adapters/vapi',
@@ -215,8 +215,8 @@ const SEO_SECTIONS = [
   {
     id: 'roadmap',
     title: 'OpenAI Realtime + Gemini Live',
-    copy: 'Prototype with controlled mode today; dedicated provider adapters are planned next.',
-    link: '/docs/providers/openai-realtime',
+    copy: 'Prototype with controlled mode today; dedicated adapters are planned next.',
+    link: '/docs/adapters/openai-realtime',
     linkLabel: 'Preview notes',
   },
 ] as const

--- a/demo/vercel.json
+++ b/demo/vercel.json
@@ -26,32 +26,32 @@
     },
     {
       "source": "/compare/voice-agent-platforms",
-      "destination": "/docs/resources/voice-agent-platforms",
+      "destination": "/docs/guides/voice-agent-platforms",
       "permanent": true
     },
     {
       "source": "/compare/voice-agent-platforms/",
-      "destination": "/docs/resources/voice-agent-platforms",
+      "destination": "/docs/guides/voice-agent-platforms",
       "permanent": true
     },
     {
       "source": "/guides/ai-voice-sales-agents",
-      "destination": "/docs/resources/ai-voice-sales-agents",
+      "destination": "/docs/guides/ai-voice-sales-agents",
       "permanent": true
     },
     {
       "source": "/guides/ai-voice-sales-agents/",
-      "destination": "/docs/resources/ai-voice-sales-agents",
+      "destination": "/docs/guides/ai-voice-sales-agents",
       "permanent": true
     },
     {
       "source": "/guides/voice-ai-customer-support",
-      "destination": "/docs/resources/voice-ai-customer-support",
+      "destination": "/docs/guides/voice-ai-customer-support",
       "permanent": true
     },
     {
       "source": "/guides/voice-ai-customer-support/",
-      "destination": "/docs/resources/voice-ai-customer-support",
+      "destination": "/docs/guides/voice-ai-customer-support",
       "permanent": true
     }
   ],

--- a/docs/adapters/gemini-live.mdx
+++ b/docs/adapters/gemini-live.mdx
@@ -36,3 +36,9 @@ Your Gemini integration owns the stateful voice session. orb-ui receives normali
 A dedicated Gemini Live adapter should focus on state normalization, audio volume, and error handling. It should not hide important session setup details from the app.
 
 Until that adapter exists, controlled mode is the correct path.
+
+## Related
+
+- [Custom integrations](/adapters/custom)
+- [Voice agent UI guide](/guides/voice-agent-ui)
+- [Voice agent platforms guide](/guides/voice-agent-platforms)

--- a/docs/adapters/openai-realtime.mdx
+++ b/docs/adapters/openai-realtime.mdx
@@ -37,4 +37,4 @@ Until that exists, controlled mode is the honest API.
 
 - [Custom integrations](/adapters/custom)
 - [Voice agent UI guide](/guides/voice-agent-ui)
-- [Provider platforms comparison](/resources/voice-agent-platforms)
+- [Voice agent platforms guide](/guides/voice-agent-platforms)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,8 +71,8 @@
           "adapters/vapi",
           "adapters/elevenlabs",
           "adapters/custom",
-          "providers/openai-realtime",
-          "providers/gemini-live"
+          "adapters/openai-realtime",
+          "adapters/gemini-live"
         ]
       },
       {
@@ -81,9 +81,9 @@
         "pages": [
           "guides/voice-agent-ui",
           "examples/voice-orb-ui",
-          "resources/voice-agent-platforms",
-          "resources/ai-voice-sales-agents",
-          "resources/voice-ai-customer-support"
+          "guides/voice-agent-platforms",
+          "guides/ai-voice-sales-agents",
+          "guides/voice-ai-customer-support"
         ]
       }
     ]
@@ -107,19 +107,59 @@
     },
     {
       "source": "/docs/openai-realtime-voice-ui",
-      "destination": "/docs/providers/openai-realtime"
+      "destination": "/docs/adapters/openai-realtime"
     },
     {
       "source": "/docs/openai-realtime-voice-ui/",
-      "destination": "/docs/providers/openai-realtime"
+      "destination": "/docs/adapters/openai-realtime"
     },
     {
       "source": "/docs/gemini-live-voice-ui",
-      "destination": "/docs/providers/gemini-live"
+      "destination": "/docs/adapters/gemini-live"
     },
     {
       "source": "/docs/gemini-live-voice-ui/",
-      "destination": "/docs/providers/gemini-live"
+      "destination": "/docs/adapters/gemini-live"
+    },
+    {
+      "source": "/docs/providers/openai-realtime",
+      "destination": "/docs/adapters/openai-realtime"
+    },
+    {
+      "source": "/docs/providers/openai-realtime/",
+      "destination": "/docs/adapters/openai-realtime"
+    },
+    {
+      "source": "/docs/providers/gemini-live",
+      "destination": "/docs/adapters/gemini-live"
+    },
+    {
+      "source": "/docs/providers/gemini-live/",
+      "destination": "/docs/adapters/gemini-live"
+    },
+    {
+      "source": "/docs/resources/voice-agent-platforms",
+      "destination": "/docs/guides/voice-agent-platforms"
+    },
+    {
+      "source": "/docs/resources/voice-agent-platforms/",
+      "destination": "/docs/guides/voice-agent-platforms"
+    },
+    {
+      "source": "/docs/resources/ai-voice-sales-agents",
+      "destination": "/docs/guides/ai-voice-sales-agents"
+    },
+    {
+      "source": "/docs/resources/ai-voice-sales-agents/",
+      "destination": "/docs/guides/ai-voice-sales-agents"
+    },
+    {
+      "source": "/docs/resources/voice-ai-customer-support",
+      "destination": "/docs/guides/voice-ai-customer-support"
+    },
+    {
+      "source": "/docs/resources/voice-ai-customer-support/",
+      "destination": "/docs/guides/voice-ai-customer-support"
     }
   ]
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -57,7 +57,7 @@
       {
         "group": "Start",
         "icon": "rocket",
-        "pages": ["quickstart", "installation"]
+        "pages": ["index", "quickstart", "installation"]
       },
       {
         "group": "Reference",

--- a/docs/guides/ai-voice-sales-agents.mdx
+++ b/docs/guides/ai-voice-sales-agents.mdx
@@ -43,3 +43,8 @@ export function SalesAgentCallStatus({ callState, volume }) {
   return <Orb state={callState} volume={volume} theme="circle" />
 }
 ```
+
+## Related
+
+- [Voice agent UI guide](/guides/voice-agent-ui)
+- [Voice agent platforms guide](/guides/voice-agent-platforms)

--- a/docs/guides/voice-agent-platforms.mdx
+++ b/docs/guides/voice-agent-platforms.mdx
@@ -33,5 +33,5 @@ That distinction is better for trust and more useful for developers than pretend
 
 - [Vapi adapter](/adapters/vapi)
 - [ElevenLabs adapter](/adapters/elevenlabs)
-- [OpenAI Realtime voice UI](/providers/openai-realtime)
-- [Gemini Live voice UI](/providers/gemini-live)
+- [OpenAI Realtime adapter](/adapters/openai-realtime)
+- [Gemini Live adapter](/adapters/gemini-live)

--- a/docs/guides/voice-ai-customer-support.mdx
+++ b/docs/guides/voice-ai-customer-support.mdx
@@ -43,3 +43,8 @@ export function SupportVoiceStatus({ state, volume }) {
   return <Orb state={state} volume={volume} theme="bars" />
 }
 ```
+
+## Related
+
+- [Voice agent UI guide](/guides/voice-agent-ui)
+- [Voice agent platforms guide](/guides/voice-agent-platforms)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: Documentation
+title: Overview
 description: Build polished React voice agent UIs with animated orbs, provider adapters, audio-reactive themes, and controlled mode.
 ---
 
-# orb-ui documentation
+# orb-ui docs overview
 
 orb-ui is a React UI layer for realtime voice agents. It gives your app an animated voice orb, audio-reactive themes, provider adapters, and a controlled mode that can sit on top of custom voice AI stacks.
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -36,7 +36,7 @@ Use an adapter when a supported provider owns the voice session. Use controlled 
 - Start with [controlled mode](/adapters/custom) when you are prototyping or wiring a custom realtime voice stack.
 - Use the [Vapi adapter](/adapters/vapi) for Vapi assistants.
 - Use the [ElevenLabs adapter](/adapters/elevenlabs) for ElevenLabs conversational agents.
-- Use [OpenAI Realtime](/providers/openai-realtime) or [Gemini Live](/providers/gemini-live) through controlled mode until dedicated adapters ship.
+- Use [OpenAI Realtime](/adapters/openai-realtime) or [Gemini Live](/adapters/gemini-live) through controlled mode until dedicated adapters ship.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Add the docs index page back to the Mintlify sidebar as Overview under Start.
- Move OpenAI Realtime and Gemini Live pages under /docs/adapters so coming-soon adapters live with the rest of the adapter docs.
- Move voice agent platform, sales agent, and customer support pages under /docs/guides so the sidebar group and URL paths match.
- Update sitemap canonicals, homepage docs links, and Vercel/Mintlify redirects so old /providers and /resources URLs point to the standardized paths.

## Validation
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm build:demo
- pnpm dlx mint@latest broken-links