### PR TITLE
Fix legacy docs redirects

### DIFF
--- a/demo/vercel.json
+++ b/demo/vercel.json
@@ -53,6 +53,96 @@
       "source": "/guides/voice-ai-customer-support/",
       "destination": "/docs/guides/voice-ai-customer-support",
       "permanent": true
+    },
+    {
+      "source": "/docs/vapi-voice-ui",
+      "destination": "/docs/adapters/vapi",
+      "permanent": true
+    },
+    {
+      "source": "/docs/vapi-voice-ui/",
+      "destination": "/docs/adapters/vapi",
+      "permanent": true
+    },
+    {
+      "source": "/docs/elevenlabs-voice-ui",
+      "destination": "/docs/adapters/elevenlabs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/elevenlabs-voice-ui/",
+      "destination": "/docs/adapters/elevenlabs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/openai-realtime-voice-ui",
+      "destination": "/docs/adapters/openai-realtime",
+      "permanent": true
+    },
+    {
+      "source": "/docs/openai-realtime-voice-ui/",
+      "destination": "/docs/adapters/openai-realtime",
+      "permanent": true
+    },
+    {
+      "source": "/docs/gemini-live-voice-ui",
+      "destination": "/docs/adapters/gemini-live",
+      "permanent": true
+    },
+    {
+      "source": "/docs/gemini-live-voice-ui/",
+      "destination": "/docs/adapters/gemini-live",
+      "permanent": true
+    },
+    {
+      "source": "/docs/providers/openai-realtime",
+      "destination": "/docs/adapters/openai-realtime",
+      "permanent": true
+    },
+    {
+      "source": "/docs/providers/openai-realtime/",
+      "destination": "/docs/adapters/openai-realtime",
+      "permanent": true
+    },
+    {
+      "source": "/docs/providers/gemini-live",
+      "destination": "/docs/adapters/gemini-live",
+      "permanent": true
+    },
+    {
+      "source": "/docs/providers/gemini-live/",
+      "destination": "/docs/adapters/gemini-live",
+      "permanent": true
+    },
+    {
+      "source": "/docs/resources/voice-agent-platforms",
+      "destination": "/docs/guides/voice-agent-platforms",
+      "permanent": true
+    },
+    {
+      "source": "/docs/resources/voice-agent-platforms/",
+      "destination": "/docs/guides/voice-agent-platforms",
+      "permanent": true
+    },
+    {
+      "source": "/docs/resources/ai-voice-sales-agents",
+      "destination": "/docs/guides/ai-voice-sales-agents",
+      "permanent": true
+    },
+    {
+      "source": "/docs/resources/ai-voice-sales-agents/",
+      "destination": "/docs/guides/ai-voice-sales-agents",
+      "permanent": true
+    },
+    {
+      "source": "/docs/resources/voice-ai-customer-support",
+      "destination": "/docs/guides/voice-ai-customer-support",
+      "permanent": true
+    },
+    {
+      "source": "/docs/resources/voice-ai-customer-support/",
+      "destination": "/docs/guides/voice-ai-customer-support",
+      "permanent": true
     }
   ],
   "rewrites": [

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -90,76 +90,76 @@
   },
   "redirects": [
     {
-      "source": "/docs/vapi-voice-ui",
-      "destination": "/docs/adapters/vapi"
+      "source": "/vapi-voice-ui",
+      "destination": "/adapters/vapi"
     },
     {
-      "source": "/docs/vapi-voice-ui/",
-      "destination": "/docs/adapters/vapi"
+      "source": "/vapi-voice-ui/",
+      "destination": "/adapters/vapi"
     },
     {
-      "source": "/docs/elevenlabs-voice-ui",
-      "destination": "/docs/adapters/elevenlabs"
+      "source": "/elevenlabs-voice-ui",
+      "destination": "/adapters/elevenlabs"
     },
     {
-      "source": "/docs/elevenlabs-voice-ui/",
-      "destination": "/docs/adapters/elevenlabs"
+      "source": "/elevenlabs-voice-ui/",
+      "destination": "/adapters/elevenlabs"
     },
     {
-      "source": "/docs/openai-realtime-voice-ui",
-      "destination": "/docs/adapters/openai-realtime"
+      "source": "/openai-realtime-voice-ui",
+      "destination": "/adapters/openai-realtime"
     },
     {
-      "source": "/docs/openai-realtime-voice-ui/",
-      "destination": "/docs/adapters/openai-realtime"
+      "source": "/openai-realtime-voice-ui/",
+      "destination": "/adapters/openai-realtime"
     },
     {
-      "source": "/docs/gemini-live-voice-ui",
-      "destination": "/docs/adapters/gemini-live"
+      "source": "/gemini-live-voice-ui",
+      "destination": "/adapters/gemini-live"
     },
     {
-      "source": "/docs/gemini-live-voice-ui/",
-      "destination": "/docs/adapters/gemini-live"
+      "source": "/gemini-live-voice-ui/",
+      "destination": "/adapters/gemini-live"
     },
     {
-      "source": "/docs/providers/openai-realtime",
-      "destination": "/docs/adapters/openai-realtime"
+      "source": "/providers/openai-realtime",
+      "destination": "/adapters/openai-realtime"
     },
     {
-      "source": "/docs/providers/openai-realtime/",
-      "destination": "/docs/adapters/openai-realtime"
+      "source": "/providers/openai-realtime/",
+      "destination": "/adapters/openai-realtime"
     },
     {
-      "source": "/docs/providers/gemini-live",
-      "destination": "/docs/adapters/gemini-live"
+      "source": "/providers/gemini-live",
+      "destination": "/adapters/gemini-live"
     },
     {
-      "source": "/docs/providers/gemini-live/",
-      "destination": "/docs/adapters/gemini-live"
+      "source": "/providers/gemini-live/",
+      "destination": "/adapters/gemini-live"
     },
     {
-      "source": "/docs/resources/voice-agent-platforms",
-      "destination": "/docs/guides/voice-agent-platforms"
+      "source": "/resources/voice-agent-platforms",
+      "destination": "/guides/voice-agent-platforms"
     },
     {
-      "source": "/docs/resources/voice-agent-platforms/",
-      "destination": "/docs/guides/voice-agent-platforms"
+      "source": "/resources/voice-agent-platforms/",
+      "destination": "/guides/voice-agent-platforms"
     },
     {
-      "source": "/docs/resources/ai-voice-sales-agents",
-      "destination": "/docs/guides/ai-voice-sales-agents"
+      "source": "/resources/ai-voice-sales-agents",
+      "destination": "/guides/ai-voice-sales-agents"
     },
     {
-      "source": "/docs/resources/ai-voice-sales-agents/",
-      "destination": "/docs/guides/ai-voice-sales-agents"
+      "source": "/resources/ai-voice-sales-agents/",
+      "destination": "/guides/ai-voice-sales-agents"
     },
     {
-      "source": "/docs/resources/voice-ai-customer-support",
-      "destination": "/docs/guides/voice-ai-customer-support"
+      "source": "/resources/voice-ai-customer-support",
+      "destination": "/guides/voice-ai-customer-support"
     },
     {
-      "source": "/docs/resources/voice-ai-customer-support/",
-      "destination": "/docs/guides/voice-ai-customer-support"
+      "source": "/resources/voice-ai-customer-support/",
+      "destination": "/guides/voice-ai-customer-support"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix Mintlify redirect paths to be relative to the docs deployment root instead of including the public /docs prefix.
- Add Vercel redirects for legacy public /docs/... URLs before the Mintlify rewrite so already-submitted sitemap URLs land on the standardized docs paths.

## Validation
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm build:demo
- pnpm dlx mint@latest broken-links

## Notes
- Mintlify deployment settings are now pointed at main with docs.json in /docs.
- New canonical docs URLs are already live after that settings fix; this PR preserves SEO from the old provider/resource URLs.