### PR TITLE
Add PostHog analytics to Mintlify docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,6 +52,13 @@
       "twitter:image": "https://orb-ui.com/og-image.jpg"
     }
   },
+  "integrations": {
+    "posthog": {
+      "apiKey": "phc_U5BI9zJCRMtmbd1nhlpg2e0cdsAymmgdbZpFYbVXBJQ",
+      "apiHost": "https://us.i.posthog.com",
+      "sessionRecording": true
+    }
+  },
   "navigation": {
     "groups": [
       {


### PR DESCRIPTION
## Summary
- add Mintlify's native PostHog integration to docs/docs.json
- use the existing PostHog project key and US API host
- enable session recording for docs pages

## Verification
- node JSON parse check for docs/docs.json
- pnpm format:check