### PR TITLE
Version Packages

### DIFF
--- a/.changeset/tiny-orbs-tap.md
+++ b/.changeset/tiny-orbs-tap.md
@@ -1,5 +1,0 @@
----
-'orb-ui': patch
----
-
-Improve package type exports, provider adapter examples, ElevenLabs adapter typing, and clickable Orb accessibility.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,12 @@ jobs:
       - name: Run checks
         run: pnpm check
 
-      - name: Create release PR
+      - name: Create release PR or publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
+          publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to npm
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: pnpm release
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,3 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# orb-ui
+
+## 0.2.4
+
+### Patch Changes
+
+- d3759d7: Improve package type exports, provider adapter examples, ElevenLabs adapter typing, and clickable Orb accessibility.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orb-ui",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "React voice agent UI components with animated voice orbs, audio-reactive themes, and adapters for Vapi, ElevenLabs, and custom realtime voice AI apps.",
   "type": "module",
   "main": "./dist/orb-ui.cjs",


### PR DESCRIPTION
This release PR was generated by `changesets/action` on `main`, but the workflow failed while opening the pull request because the repository was blocking `GITHUB_TOKEN` from creating PRs.

The branch was already pushed by the action, so this PR preserves the generated release changes:

- Bump `orb-ui` from `0.2.3` to `0.2.4`
- Add the generated changelog entry
- Remove the consumed changeset file
- Harden the release workflow so Changesets owns both release-PR creation and npm publishing

The workflow is now set up for npm Trusted Publishing: it has `id-token: write` and does not require `NPM_TOKEN`. Before merging, configure npm trusted publishing for package `orb-ui` with GitHub Actions repo `alexanderqchen/orb-ui` and workflow file `release.yml`.

After this merges, the release workflow should run the publish path.