### PR TITLE
[codex] Redirect index URLs to homepage

### DIFF
--- a/demo/vercel.json
+++ b/demo/vercel.json
@@ -5,6 +5,21 @@
   "outputDirectory": "dist",
   "redirects": [
     {
+      "source": "/index",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/index/",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/index.html",
+      "destination": "/",
+      "permanent": true
+    },
+    {
       "source": "/guides/voice-agent-ui",
       "destination": "/docs/guides/voice-agent-ui",
       "permanent": true


### PR DESCRIPTION
## What changed

Adds permanent Vercel redirects for `/index`, `/index/`, and `/index.html` to the homepage.

## Why

Google Search Console reported `https://orb-ui.com/index` as a discovered 404. This appears to be a historical or externally discovered homepage alias rather than a URL generated by the repo.

## Impact

After deploy, Google and users who hit these index-style homepage URLs will be redirected to `/` instead of receiving a 404.

## Validation

- Confirmed live `https://orb-ui.com/index` currently returns 404 before the fix.
- Confirmed no repo links or sitemap entries generate `/index`.
- Parsed `demo/vercel.json` successfully with Node.