### PR TITLE
[codex] docs: add PR standards and roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Instructions
+
+This repo is intentionally AI-native. Follow `CONTRIBUTING.md` first, then these durable agent rules.
+
+## PR and Release Standards
+
+- Use Conventional Commit-style PR titles.
+- Use `!` for intentional breaking changes, for example `feat!: introduce signal-based adapter API`.
+- Breaking API changes need a changeset, migration notes, and matching docs/examples updates.
+- Do not mark a change as breaking for internal-only refactors.
+
+## Product Direction
+
+- Keep public product planning in `ROADMAP.md`.
+- Do not commit private analytics, credentials, secret keys, internal research notes, or confidential timelines.
+- Use neutral public names for brand-adjacent visual inspiration; avoid third-party brand names in public theme API names.
+- New themes belong in `src/themes/`; new provider adapters belong in `src/adapters/`.
+
+## Verification
+
+- Run focused tests/typechecks for the touched surface when possible.
+- Before opening a release PR, run `pnpm check`.
+- If verification cannot be run, explain why in the PR notes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ This repo is intentionally AI-native. Follow `CONTRIBUTING.md` first, then these
 ## Product Direction
 
 - Keep public product planning in `ROADMAP.md`.
+- When making meaningful progress on a roadmap item, update `ROADMAP.md` in the same PR. Mark completed work, adjust status/next steps, or explain in the PR notes why no roadmap update was needed.
+- Treat docs and examples as part of the finished change. If behavior, API, adapters, themes, or project direction changes, update the relevant markdown/docs in the same PR.
 - Do not commit private analytics, credentials, secret keys, internal research notes, or confidential timelines.
 - Use neutral public names for brand-adjacent visual inspiration; avoid third-party brand names in public theme API names.
 - New themes belong in `src/themes/`; new provider adapters belong in `src/adapters/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,44 @@ pnpm changeset
 
 ## Ground rules (for everyone)
 
-- Don't break the public API (`Orb` props, `OrbAdapter` interface, `OrbState` union)
+- Treat the public API (`Orb` props, `OrbAdapter` interface, `OrbState` union) carefully. Breaking changes are allowed only when they are intentional, documented, and released with a migration note.
 - New themes go in `src/themes/`, new adapters in `src/adapters/`
 - Run `pnpm check` before opening a PR
 - Keep bundle size in mind — no heavy dependencies without discussion
+
+---
+
+## PR titles and breaking changes
+
+Use Conventional Commit-style PR titles so release notes stay clear after squash merges:
+
+```text
+feat: add a new theme
+fix: normalize ElevenLabs output volume
+docs: clarify custom adapter setup
+refactor: simplify theme animation state
+feat!: introduce signal-based adapter API
+```
+
+Use `!` only when the PR intentionally changes user-facing behavior or public API in a way that may require app code changes. For breaking changes:
+
+- Put `!` in the PR title, for example `feat!: introduce signal-based adapter API`
+- Add a changeset with the migration note
+- Update affected docs and examples
+- Mention what changed, why it changed, and how users should migrate
+
+Because orb-ui is still pre-1.0, breaking changes can be reasonable when they make the library much better. They should still be explicit and easy to follow.
+
+---
+
+## Roadmap
+
+Public roadmap work lives in [ROADMAP.md](./ROADMAP.md). Keep it useful for contributors and users, not exhaustive:
+
+- Include the next meaningful product directions
+- Avoid private analytics, credentials, internal notes, or confidential timelines
+- Use neutral public language for brand-adjacent visual inspiration
+- Update it when a direction changes materially
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,9 +114,10 @@ Because orb-ui is still pre-1.0, breaking changes can be reasonable when they ma
 Public roadmap work lives in [ROADMAP.md](./ROADMAP.md). Keep it useful for contributors and users, not exhaustive:
 
 - Include the next meaningful product directions
+- Update it when meaningful progress lands, not only when direction changes
 - Avoid private analytics, credentials, internal notes, or confidential timelines
 - Use neutral public language for brand-adjacent visual inspiration
-- Update it when a direction changes materially
+- If a PR completes or substantially advances a roadmap item, update the roadmap in that PR or explain why no roadmap change was needed
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,55 @@
+# orb-ui Roadmap
+
+This roadmap is public planning, not a promise of dates or exact release contents. It should help contributors understand where the project is headed without exposing private analytics, credentials, or internal notes.
+
+## Near Term
+
+### Signal-based adapter API
+
+Introduce a richer adapter signal model so providers can report state, input volume, output volume, and errors as one coherent update.
+
+Target direction:
+
+- Add an `OrbSignal` type
+- Add a `signal` prop for controlled usage
+- Support `inputVolume` and `outputVolume`
+- Add a `thinking` voice state
+- Document migration from callback-object adapters
+- Remove surprising global audio behavior from `Orb`
+
+### OpenAI Realtime adapter
+
+Add first-class OpenAI Realtime support after the signal API lands. The initial adapter should focus on browser voice UI use cases and keep server-side token/session creation explicit in user apps.
+
+### Gemini Live adapter
+
+Add Gemini Live support after the OpenAI Realtime adapter or in parallel if the signal API is ready. The adapter should normalize Live API session state and audio levels while keeping the underlying session setup understandable.
+
+## Experience
+
+### More impressive themes
+
+Add polished themes that feel production-ready, not just minimal examples. Public API names should stay neutral and ownable.
+
+Candidate theme directions:
+
+- `halo`: luminous orb-style assistant presence
+- `prism`: colorful layered realtime voice presence
+- `studio`: waveform-forward voice interface
+- `aurora`: fluid multicolor assistant motion
+
+### Better demo
+
+Make the homepage demo feel like an actual product surface:
+
+- Clickable simulated session
+- Live theme switching
+- Clear adapter examples
+- Better examples for provider and controlled modes
+
+## Ongoing
+
+- Keep docs search-friendly and implementation-honest
+- Keep adapter code dependency-light
+- Keep animations accessible, performant, and responsive
+- Prefer small provider-specific adapters over one opaque universal client


### PR DESCRIPTION
## Summary

- Document Conventional Commit-style PR title standards, including `!` for intentional breaking changes.
- Add `AGENTS.md` so future agent runs inherit PR, release, roadmap, documentation, and verification expectations.
- Add a public `ROADMAP.md` for near-term adapter API, provider adapter, theme, and demo direction.
- Require agents/contributors to update roadmap and documentation when meaningful progress lands, or explain why no roadmap update was needed.

## Why

The signal-based adapter API work should be handled as an intentional breaking-change process, with public standards for titles, migration notes, and release communication. The roadmap gives contributors a public place to understand the project direction without exposing private analytics, credentials, or internal notes, and the contribution rules keep that public plan current as work progresses.

## Validation

- `pnpm format:check`