### PR TITLE
feat: simplify LiveKit adapter setup

### DIFF
--- a/.changeset/smooth-livekit-sessions.md
+++ b/.changeset/smooth-livekit-sessions.md
@@ -1,0 +1,8 @@
+---
+'orb-ui': minor
+---
+
+Add a simplified `orb-ui/adapters/livekit` browser entrypoint. LiveKit users can now provide a token
+endpoint and optional agent name while orb-ui owns the Room, TokenSource, audio analysers,
+microphone lifecycle, and unique room naming. The existing `orb-ui/adapters` LiveKit factory remains
+available for advanced app-owned Room, custom fetcher, raw credential, and runtime override modes.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The only difference is how the adapter obtains a provider session:
 | --------------- | ------------------------------------------------------------------------ |
 | Vapi            | Pass a configured Vapi client plus `assistantId`                         |
 | ElevenLabs      | Pass `Conversation` plus an `agentId`, signed URL, or conversation token |
-| LiveKit         | Pass LiveKit runtime helpers plus a token source or endpoint             |
+| LiveKit         | Provide a token endpoint and optional agent name                         |
 | Pipecat         | Pass a configured `PipecatClient` plus its connect callback              |
 | OpenAI Realtime | Return a fresh short-lived client secret from `getClientSecret`          |
 | Gemini Live     | Open the official Google Live session in `connect`                       |
@@ -117,18 +117,12 @@ function App() {
 ### With LiveKit
 
 ```jsx
-import { Room, TokenSource, createAudioAnalyser } from 'livekit-client'
 import { Orb } from 'orb-ui'
-import { createLiveKitAdapter } from 'orb-ui/adapters'
+import { createLiveKitAdapter } from 'orb-ui/adapters/livekit'
 
 const adapter = createLiveKitAdapter({
-  tokenSource: TokenSource.endpoint('/api/livekit-token'),
-  tokenOptions: {
-    agentName: 'your-agent-name',
-    roomName: () => `orb-${crypto.randomUUID()}`,
-  },
-  createAudioAnalyser,
-  RoomClass: Room,
+  tokenEndpoint: '/api/livekit-token',
+  agentName: 'your-agent-name',
 })
 
 function App() {
@@ -136,8 +130,9 @@ function App() {
 }
 ```
 
-The LiveKit adapter meters the local microphone while listening and the remote agent audio while
-speaking, so every audio-reactive theme follows the active side of the conversation.
+The LiveKit entrypoint creates the room and token source, assigns a fresh room name, and meters both
+sides of the conversation. Existing-room and custom-runtime modes remain available from the
+advanced `orb-ui/adapters` entrypoint.
 
 ### With Pipecat
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,9 @@ Target direction:
 First-class LiveKit Agents support includes signal-native state, local microphone and remote agent
 volume metering, attached agent audio, and token-source based connection setup. The adapter should
 keep browser auth explicit by favoring token endpoints and LiveKit sandbox token servers over raw
-pasted participant tokens.
+pasted participant tokens. The dedicated browser entrypoint owns the standard LiveKit SDK runtime,
+token source, and room naming so the normal setup only needs a token endpoint and optional agent
+name; advanced app-owned Room modes remain available separately.
 
 ### Pipecat adapter — complete
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -85,18 +85,12 @@ export function VoiceOrb() {
   return <Orb adapter={adapter} theme="circle" aria-label="Start voice assistant" />
 }`
 
-const LIVEKIT_CODE = `import { Room, TokenSource, createAudioAnalyser } from "livekit-client"
-import { Orb } from "orb-ui"
-import { createLiveKitAdapter } from "orb-ui/adapters"
+const LIVEKIT_CODE = `import { Orb } from "orb-ui"
+import { createLiveKitAdapter } from "orb-ui/adapters/livekit"
 
 const adapter = createLiveKitAdapter({
-  tokenSource: TokenSource.endpoint("/api/livekit-token"),
-  tokenOptions: {
-    agentName: "your-agent-name",
-    roomName: () => \`orb-\${crypto.randomUUID()}\`
-  },
-  createAudioAnalyser,
-  RoomClass: Room,
+  tokenEndpoint: "/api/livekit-token",
+  agentName: "your-agent-name"
 })
 
 function App() {

--- a/demo/src/provider-playground.tsx
+++ b/demo/src/provider-playground.tsx
@@ -594,31 +594,27 @@ function createProviderAdapter(
 
   if (provider === 'livekit' && getProviderReady(provider, config)) {
     return createLazyAdapter(async () => {
-      const { Room, TokenSource, createAudioAnalyser } = await import('livekit-client')
       if (config.liveKitConnectionMode === 'sandbox') {
-        return createLiveKitAdapter({
-          tokenSource: TokenSource.sandboxTokenServer(config.liveKitSandboxId),
-          tokenOptions: {
-            agentName: config.liveKitAgentName,
-            roomName: () => createLiveKitRoomName(config.liveKitRoomPrefix),
-          },
-          createAudioAnalyser,
-          RoomClass: Room,
+        const { createLiveKitAdapter: createManagedLiveKitAdapter } =
+          await import('orb-ui/adapters/livekit')
+        return createManagedLiveKitAdapter({
+          sandboxId: config.liveKitSandboxId,
+          agentName: config.liveKitAgentName,
+          roomName: () => createLiveKitRoomName(config.liveKitRoomPrefix),
         })
       }
 
       if (config.liveKitConnectionMode === 'endpoint') {
-        return createLiveKitAdapter({
-          tokenSource: TokenSource.endpoint(config.liveKitTokenEndpoint),
-          tokenOptions: {
-            agentName: config.liveKitAgentName,
-            roomName: () => createLiveKitRoomName(config.liveKitRoomPrefix),
-          },
-          createAudioAnalyser,
-          RoomClass: Room,
+        const { createLiveKitAdapter: createManagedLiveKitAdapter } =
+          await import('orb-ui/adapters/livekit')
+        return createManagedLiveKitAdapter({
+          tokenEndpoint: config.liveKitTokenEndpoint,
+          agentName: config.liveKitAgentName,
+          roomName: () => createLiveKitRoomName(config.liveKitRoomPrefix),
         })
       }
 
+      const { Room, createAudioAnalyser } = await import('livekit-client')
       return createLiveKitAdapter({
         serverUrl: config.liveKitServerUrl,
         participantToken: config.liveKitParticipantToken,

--- a/docs/adapters/livekit.mdx
+++ b/docs/adapters/livekit.mdx
@@ -5,11 +5,13 @@ description: Add a LiveKit Agents voice UI to React with orb-ui's adapter, anima
 
 # LiveKit voice UI components for React
 
-LiveKit Agents handles the realtime media and agent session layer. orb-ui handles the visible React UI layer: an animated voice orb, audio-reactive feedback, and predictable states for the conversation.
+LiveKit Agents handles the realtime media and agent session layer. orb-ui handles the browser Room,
+microphone and agent audio, normalized conversation state, and the visible React UI.
 
-The token-endpoint example below is the intended application setup. Sandbox, existing-room, raw
-credential, and custom fetcher modes are advanced alternatives; you do not need to configure all of
-them.
+The token-endpoint example below is the intended application setup. The dedicated LiveKit
+entrypoint imports the official SDK only for LiveKit users and hides its mechanical constructors and
+audio analyser setup. Existing-room, raw credential, and custom fetcher modes remain advanced
+alternatives.
 
 ## Install
 
@@ -22,21 +24,17 @@ npm install orb-ui livekit-client
 ## Use a token endpoint
 
 In the recommended setup, your app exposes a token endpoint and the adapter fetches fresh LiveKit
-connection details when the orb starts. The endpoint should return `{ serverUrl, participantToken }`.
+connection details when the orb starts. Use LiveKit's TokenSource endpoint contract: the JSON
+response includes `{ server_url, participant_token }`. The adapter generates a unique
+`orb-<uuid>` room name for every start.
 
 ```tsx
-import { Room, TokenSource, createAudioAnalyser } from 'livekit-client'
 import { Orb } from 'orb-ui'
-import { createLiveKitAdapter } from 'orb-ui/adapters'
+import { createLiveKitAdapter } from 'orb-ui/adapters/livekit'
 
 const adapter = createLiveKitAdapter({
-  tokenSource: TokenSource.endpoint('/api/livekit-token'),
-  tokenOptions: {
-    agentName: 'your-agent-name',
-    roomName: () => `orb-${crypto.randomUUID()}`,
-  },
-  createAudioAnalyser,
-  RoomClass: Room,
+  tokenEndpoint: '/api/livekit-token',
+  agentName: 'your-agent-name',
 })
 
 export function LiveKitVoiceUI() {
@@ -44,9 +42,46 @@ export function LiveKitVoiceUI() {
 }
 ```
 
-You can also provide your own fetcher:
+`agentName` is optional when your token endpoint already decides which agent to dispatch. Override
+`roomName` only when your app needs a specific room:
 
 ```tsx
+const adapter = createLiveKitAdapter({
+  tokenEndpoint: '/api/livekit-token',
+  agentName: 'your-agent-name',
+  roomName: () => `support-${customerId}-${crypto.randomUUID()}`,
+})
+```
+
+## Use a LiveKit Cloud sandbox
+
+For local and preview testing, LiveKit's sandbox token server can generate connection details without
+your own backend. Do not use this mode in production.
+
+```tsx
+import { Orb } from 'orb-ui'
+import { createLiveKitAdapter } from 'orb-ui/adapters/livekit'
+
+const adapter = createLiveKitAdapter({
+  sandboxId: 'token-server-abc123',
+  agentName: 'your-agent-name',
+})
+
+export function LiveKitVoiceUI() {
+  return <Orb adapter={adapter} theme="circle" aria-label="Start LiveKit assistant" />
+}
+```
+
+## Advanced connection ownership
+
+Import from `orb-ui/adapters` when your application already owns the connection fetcher, Room,
+token source, or runtime helpers. For example, a custom connection fetcher can inspect your own
+application state:
+
+```tsx
+import { Room, createAudioAnalyser } from 'livekit-client'
+import { createLiveKitAdapter } from 'orb-ui/adapters'
+
 const adapter = createLiveKitAdapter({
   getConnectionDetails: async ({ agentName, roomName }) => {
     const response = await fetch('/api/livekit-token', {
@@ -63,31 +98,6 @@ const adapter = createLiveKitAdapter({
   createAudioAnalyser,
   RoomClass: Room,
 })
-```
-
-## Use a LiveKit Cloud sandbox
-
-For local and preview testing, LiveKit's sandbox token server can generate connection details without
-your own backend. Do not use this mode in production.
-
-```tsx
-import { Room, TokenSource, createAudioAnalyser } from 'livekit-client'
-import { Orb } from 'orb-ui'
-import { createLiveKitAdapter } from 'orb-ui/adapters'
-
-const adapter = createLiveKitAdapter({
-  tokenSource: TokenSource.sandboxTokenServer('token-server-abc123'),
-  tokenOptions: {
-    agentName: 'your-agent-name',
-    roomName: () => `orb-${crypto.randomUUID()}`,
-  },
-  createAudioAnalyser,
-  RoomClass: Room,
-})
-
-export function LiveKitVoiceUI() {
-  return <Orb adapter={adapter} theme="circle" aria-label="Start LiveKit assistant" />
-}
 ```
 
 ## Use an existing room
@@ -135,15 +145,17 @@ The adapter reads the agent participant's `lk.agent.state` attribute and maps Li
 - `disconnected` -> `idle`
 - `failed` -> `error`
 
-LiveKit remote agent audio is attached when available. The adapter uses `createAudioAnalyser` for
-both sides of the conversation: the local microphone emits normalized `inputVolume` while the agent
-is listening, and remote agent audio emits normalized `outputVolume` while the agent is speaking.
-The shared `volume` value follows whichever side is active so every orb-ui theme reacts correctly.
+LiveKit remote agent audio is attached when available. The recommended browser entrypoint creates
+the SDK audio analysers automatically: the local microphone emits normalized `inputVolume` while
+the agent is listening, and remote agent audio emits normalized `outputVolume` while the agent is
+speaking. The shared `volume` value follows whichever side is active so every orb-ui theme reacts
+correctly.
 
 ## Token handling
 
-Do not create LiveKit access tokens in the browser. Use `TokenSource.endpoint`, `getConnectionDetails`,
-or another server-backed flow to generate short-lived participant tokens.
+Do not create LiveKit access tokens in the browser. Point `tokenEndpoint` at a server-backed route
+that generates short-lived participant tokens. `TokenSource` and `getConnectionDetails` remain
+available through the advanced entrypoint when your application needs to own that behavior.
 
 ## Controlled mode
 

--- a/docs/adapters/overview.mdx
+++ b/docs/adapters/overview.mdx
@@ -21,19 +21,33 @@ including normalized input and output volume when the provider exposes audio.
 
 ## Setup at a glance
 
-| Provider        | Browser code you provide                                | What orb-ui owns                                                                  |
-| --------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Vapi            | A configured `Vapi` client and assistant ID             | Provider event mapping and output metering                                        |
-| ElevenLabs      | The `Conversation` class and agent/session credential   | Session lifecycle, state mapping, playback, and both volume levels                |
-| LiveKit         | LiveKit runtime helpers plus a token source or endpoint | Room lifecycle, agent discovery, playback, and both volume levels                 |
-| Pipecat         | A configured `PipecatClient` and its connect callback   | RTVI state mapping, remote playback, and both volume levels                       |
-| OpenAI Realtime | A callback that returns a fresh client secret           | Browser WebRTC, microphone, playback, state, and both volume levels               |
-| Gemini Live     | A callback that opens the official Google Live session  | Microphone PCM streaming, turn detection, playback, state, and both volume levels |
+| Provider        | Browser code you provide                               | What orb-ui owns                                                                  |
+| --------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| Vapi            | A configured `Vapi` client and assistant ID            | Provider event mapping and output metering                                        |
+| ElevenLabs      | The `Conversation` class and agent/session credential  | Session lifecycle, state mapping, playback, and both volume levels                |
+| LiveKit         | A token endpoint and optional agent name               | SDK setup, room lifecycle, agent discovery, playback, and both volume levels      |
+| Pipecat         | A configured `PipecatClient` and its connect callback  | RTVI state mapping, remote playback, and both volume levels                       |
+| OpenAI Realtime | A callback that returns a fresh client secret          | Browser WebRTC, microphone, playback, state, and both volume levels               |
+| Gemini Live     | A callback that opens the official Google Live session | Microphone PCM streaming, turn detection, playback, state, and both volume levels |
 
 Provider authentication stays explicit. Standard OpenAI and Gemini API keys belong on your server;
 the browser should receive only short-lived provider credentials. LiveKit participant tokens should
 also be minted on a server. Pipecat Cloud can use its public agent-start key in the browser while
 private deployment credentials remain server-side.
+
+LiveKit's recommended browser entrypoint keeps the SDK mechanical details out of application code:
+
+```tsx
+import { createLiveKitAdapter } from 'orb-ui/adapters/livekit'
+
+const adapter = createLiveKitAdapter({
+  tokenEndpoint: '/api/livekit-token',
+  agentName: 'your-agent-name',
+})
+```
+
+It creates a fresh room name for every start. Import the advanced factory from `orb-ui/adapters`
+only when your app already owns a Room, token source, custom connection fetcher, or runtime helpers.
 
 ## The three connection shapes
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -49,11 +49,11 @@ npm install orb-ui @google/genai
 import {
   createElevenLabsAdapter,
   createGeminiLiveAdapter,
-  createLiveKitAdapter,
   createOpenAIRealtimeAdapter,
   createPipecatAdapter,
   createVapiAdapter,
 } from 'orb-ui/adapters'
+import { createLiveKitAdapter } from 'orb-ui/adapters/livekit'
 ```
 
 Use an adapter when a supported provider owns the voice session. Use controlled mode when your app already has session state and audio volume.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -94,18 +94,12 @@ export function ElevenLabsVoiceUI() {
 ## LiveKit
 
 ```tsx
-import { Room, TokenSource, createAudioAnalyser } from 'livekit-client'
 import { Orb } from 'orb-ui'
-import { createLiveKitAdapter } from 'orb-ui/adapters'
+import { createLiveKitAdapter } from 'orb-ui/adapters/livekit'
 
 const adapter = createLiveKitAdapter({
-  tokenSource: TokenSource.endpoint('/api/livekit-token'),
-  tokenOptions: {
-    agentName: 'your-agent-name',
-    roomName: () => `orb-${crypto.randomUUID()}`,
-  },
-  createAudioAnalyser,
-  RoomClass: Room,
+  tokenEndpoint: '/api/livekit-token',
+  agentName: 'your-agent-name',
 })
 
 export function LiveKitVoiceUI() {
@@ -114,7 +108,8 @@ export function LiveKitVoiceUI() {
 ```
 
 While the agent is listening, the adapter emits local microphone activity as `inputVolume`. While
-the agent is speaking, it emits the attached remote audio level as `outputVolume`.
+the agent is speaking, it emits the attached remote audio level as `outputVolume`. The adapter owns
+the LiveKit room, token source, audio analysis, and a fresh room name for each start.
 
 ## Pipecat
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
       "types": "./dist/adapters/index.d.ts",
       "import": "./dist/adapters.js",
       "require": "./dist/adapters.cjs"
+    },
+    "./adapters/livekit": {
+      "types": "./dist/adapters/livekit/browser.d.ts",
+      "import": "./dist/livekit-adapter.js",
+      "require": "./dist/livekit-adapter.cjs"
     }
   },
   "files": [
@@ -42,8 +47,14 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
+    "livekit-client": ">=2.20.0 <3",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "livekit-client": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
@@ -104,6 +115,9 @@
     "*": {
       "adapters": [
         "./dist/adapters/index.d.ts"
+      ],
+      "adapters/livekit": [
+        "./dist/adapters/livekit/browser.d.ts"
       ]
     }
   }

--- a/src/adapters/livekit/browser.test.ts
+++ b/src/adapters/livekit/browser.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createAdvancedLiveKitAdapter: vi.fn((config: unknown) => config),
+  createAudioAnalyser: vi.fn(),
+  endpoint: vi.fn((url: string, options?: unknown) => ({ type: 'endpoint', url, options })),
+  sandboxTokenServer: vi.fn((id: string, options?: unknown) => ({ type: 'sandbox', id, options })),
+  Room: class Room {},
+}))
+
+vi.mock('livekit-client', () => ({
+  Room: mocks.Room,
+  TokenSource: {
+    endpoint: mocks.endpoint,
+    sandboxTokenServer: mocks.sandboxTokenServer,
+  },
+  createAudioAnalyser: mocks.createAudioAnalyser,
+}))
+
+vi.mock('./index', () => ({
+  createLiveKitAdapter: mocks.createAdvancedLiveKitAdapter,
+}))
+
+import { createLiveKitAdapter } from './browser'
+
+describe('managed LiveKit browser adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates the recommended token-endpoint adapter with a fresh default room', () => {
+    createLiveKitAdapter({
+      tokenEndpoint: '/api/livekit-token',
+      tokenEndpointOptions: { headers: { Authorization: 'Bearer app-session' } },
+      agentName: 'support-agent',
+    })
+
+    expect(mocks.endpoint).toHaveBeenCalledWith('/api/livekit-token', {
+      headers: { Authorization: 'Bearer app-session' },
+    })
+    expect(mocks.createAdvancedLiveKitAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenSource: expect.objectContaining({ type: 'endpoint' }),
+        RoomClass: mocks.Room,
+        createAudioAnalyser: mocks.createAudioAnalyser,
+      }),
+    )
+
+    const advancedConfig = mocks.createAdvancedLiveKitAdapter.mock.calls[0][0] as {
+      tokenOptions: { agentName?: string; roomName: () => string }
+    }
+    expect(advancedConfig.tokenOptions.agentName).toBe('support-agent')
+    expect(advancedConfig.tokenOptions.roomName()).toMatch(/^orb-/)
+  })
+
+  it('creates sandbox adapters and forwards optional token values', () => {
+    const roomName = () => 'custom-room'
+    const participantAttributes = () => ({ plan: 'test' })
+
+    createLiveKitAdapter({
+      sandboxId: 'sandbox-123',
+      sandboxOptions: { baseUrl: 'https://sandbox.example.com' },
+      agentName: 'test-agent',
+      roomName,
+      participantAttributes,
+      enableMicrophone: false,
+    })
+
+    expect(mocks.sandboxTokenServer).toHaveBeenCalledWith('sandbox-123', {
+      baseUrl: 'https://sandbox.example.com',
+    })
+    expect(mocks.createAdvancedLiveKitAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enableMicrophone: false,
+        tokenOptions: expect.objectContaining({
+          agentName: 'test-agent',
+          roomName,
+          participantAttributes,
+        }),
+      }),
+    )
+  })
+})

--- a/src/adapters/livekit/browser.ts
+++ b/src/adapters/livekit/browser.ts
@@ -1,0 +1,99 @@
+import { Room, TokenSource, createAudioAnalyser } from 'livekit-client'
+import {
+  createLiveKitAdapter as createAdvancedLiveKitAdapter,
+  type LiveKitOrbAdapter,
+  type LiveKitTokenOptions,
+} from './index'
+
+interface LiveKitBrowserAdapterBase extends Omit<LiveKitTokenOptions, 'agentName' | 'roomName'> {
+  /** Agent dispatched into the room. Required for LiveKit Cloud sandbox sessions. */
+  agentName?: LiveKitTokenOptions['agentName']
+  /** Defaults to a fresh `orb-<uuid>` room name for every start. */
+  roomName?: LiveKitTokenOptions['roomName']
+  /** LiveKit room.connect options passed through unchanged. */
+  connectOptions?: Record<string, unknown>
+  /** Enable the local microphone after connecting. Defaults to true. */
+  enableMicrophone?: boolean
+}
+
+export type LiveKitTokenEndpointOptions = Omit<RequestInit, 'body'>
+
+export interface LiveKitSandboxOptions {
+  /** Override LiveKit's default Cloud API base URL. */
+  baseUrl?: string
+}
+
+export interface LiveKitEndpointAdapterConfig extends LiveKitBrowserAdapterBase {
+  /** LiveKit TokenSource endpoint returning `{ server_url, participant_token }`. */
+  tokenEndpoint: string
+  /** Optional fetch settings such as authenticated request headers. */
+  tokenEndpointOptions?: LiveKitTokenEndpointOptions
+  sandboxId?: never
+  sandboxOptions?: never
+}
+
+export interface LiveKitSandboxAdapterConfig extends LiveKitBrowserAdapterBase {
+  /** LiveKit Cloud sandbox token server ID. Sandbox mode is intended for testing only. */
+  sandboxId: string
+  /** The agent to dispatch into the sandbox room. */
+  agentName: NonNullable<LiveKitTokenOptions['agentName']>
+  /** Optional LiveKit sandbox host overrides. */
+  sandboxOptions?: LiveKitSandboxOptions
+  tokenEndpoint?: never
+  tokenEndpointOptions?: never
+}
+
+export type LiveKitBrowserAdapterConfig = LiveKitEndpointAdapterConfig | LiveKitSandboxAdapterConfig
+
+function createRoomName() {
+  const id =
+    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  return `orb-${id}`
+}
+
+/**
+ * Creates a managed LiveKit Agents adapter using the official browser SDK.
+ *
+ * This entrypoint owns the LiveKit Room, token source, microphone, playback,
+ * and audio analysers. Import the advanced factory from `orb-ui/adapters`
+ * only when your application already owns those pieces.
+ */
+export function createLiveKitAdapter(config: LiveKitBrowserAdapterConfig): LiveKitOrbAdapter {
+  const {
+    agentMetadata,
+    agentName,
+    connectOptions,
+    deployment,
+    enableMicrophone,
+    participantAttributes,
+    participantIdentity,
+    participantMetadata,
+    participantName,
+    roomName = createRoomName,
+  } = config
+
+  const tokenSource =
+    config.tokenEndpoint !== undefined
+      ? TokenSource.endpoint(config.tokenEndpoint, config.tokenEndpointOptions)
+      : TokenSource.sandboxTokenServer(config.sandboxId, config.sandboxOptions)
+
+  return createAdvancedLiveKitAdapter({
+    tokenSource,
+    tokenOptions: {
+      agentMetadata,
+      agentName,
+      deployment,
+      participantAttributes,
+      participantIdentity,
+      participantMetadata,
+      participantName,
+      roomName,
+    },
+    connectOptions,
+    enableMicrophone,
+    createAudioAnalyser,
+    RoomClass: Room,
+  }) as LiveKitOrbAdapter
+}
+
+export type { LiveKitOrbAdapter } from './index'

--- a/src/adapters/livekit/index.ts
+++ b/src/adapters/livekit/index.ts
@@ -50,7 +50,7 @@ interface LKCreateAudioAnalyser<TTrack = unknown> {
   (track: TTrack, options?: Record<string, unknown>): LKAnalyserResult
 }
 
-type LiveKitTokenOptionValue = string | (() => string)
+export type LiveKitTokenOptionValue = string | (() => string)
 
 export interface LiveKitConnectionDetails {
   /** LiveKit server URL, e.g. "wss://your-project.livekit.cloud". */

--- a/tests/e2e/fixture/main.tsx
+++ b/tests/e2e/fixture/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { Orb } from 'orb-ui'
 import type { OrbAdapter, OrbSignal } from 'orb-ui'
 import { createElevenLabsAdapter, createLiveKitAdapter, createVapiAdapter } from 'orb-ui/adapters'
+import { createLiveKitAdapter as createManagedLiveKitAdapter } from 'orb-ui/adapters/livekit'
 
 const IDLE_SIGNAL: OrbSignal = {
   state: 'idle',
@@ -41,7 +42,8 @@ function App() {
   const adapterExportsReady =
     typeof createVapiAdapter === 'function' &&
     typeof createElevenLabsAdapter === 'function' &&
-    typeof createLiveKitAdapter === 'function'
+    typeof createLiveKitAdapter === 'function' &&
+    typeof createManagedLiveKitAdapter === 'function'
 
   return (
     <main>

--- a/tests/package-typecheck/package-consumer.tsx
+++ b/tests/package-typecheck/package-consumer.tsx
@@ -2,10 +2,12 @@ import { Orb } from 'orb-ui'
 import {
   createElevenLabsAdapter,
   createGeminiLiveAdapter,
-  createLiveKitAdapter,
+  createLiveKitAdapter as createAdvancedLiveKitAdapter,
   createOpenAIRealtimeAdapter,
   createPipecatAdapter,
 } from 'orb-ui/adapters'
+import { createLiveKitAdapter } from 'orb-ui/adapters/livekit'
+import type { LiveKitBrowserAdapterConfig } from 'orb-ui/adapters/livekit'
 import type {
   ElevenLabsConversationClass,
   GeminiLiveSession,
@@ -63,7 +65,12 @@ const liveKitConfig: LiveKitAdapterConfig = {
   },
 }
 
-const liveKitAdapter = createLiveKitAdapter(liveKitConfig)
+const advancedLiveKitAdapter = createAdvancedLiveKitAdapter(liveKitConfig)
+const liveKitBrowserConfig: LiveKitBrowserAdapterConfig = {
+  tokenEndpoint: '/api/livekit-token',
+  agentName: 'support-agent',
+}
+const liveKitAdapter = createLiveKitAdapter(liveKitBrowserConfig)
 
 const pipecatClient: PipecatClientLike = {
   on: () => undefined,
@@ -90,6 +97,11 @@ export function PackageConsumerSmoke() {
     <>
       <Orb adapter={elevenLabsAdapter} theme="circle" aria-label="Start ElevenLabs assistant" />
       <Orb adapter={liveKitAdapter} theme="circle" aria-label="Start LiveKit assistant" />
+      <Orb
+        adapter={advancedLiveKitAdapter}
+        theme="circle"
+        aria-label="Start app-managed LiveKit assistant"
+      />
       <Orb adapter={pipecatAdapter} theme="circle" aria-label="Start Pipecat assistant" />
       <Orb adapter={openAIRealtimeAdapter} theme="circle" aria-label="Start OpenAI assistant" />
       <Orb adapter={geminiLiveAdapter} theme="circle" aria-label="Start Gemini assistant" />

--- a/tests/typecheck/provider-adapters.tsx
+++ b/tests/typecheck/provider-adapters.tsx
@@ -3,16 +3,15 @@ import { Conversation } from '@elevenlabs/client'
 import { GoogleGenAI, Modality } from '@google/genai'
 import { PipecatClient } from '@pipecat-ai/client-js'
 import { SmallWebRTCTransport } from '@pipecat-ai/small-webrtc-transport'
-import { Room, TokenSource, createAudioAnalyser } from 'livekit-client'
 import { Orb } from '../../src'
 import {
   createElevenLabsAdapter,
   createGeminiLiveAdapter,
-  createLiveKitAdapter,
   createOpenAIRealtimeAdapter,
   createPipecatAdapter,
   createVapiAdapter,
 } from '../../src/adapters'
+import { createLiveKitAdapter } from '../../src/adapters/livekit/browser'
 import type { LegacyOrbAdapter, OrbAdapter, OrbSignal } from '../../src/adapters'
 
 const vapi = new Vapi('public-key')
@@ -33,12 +32,18 @@ const tokenElevenLabsAdapter = createElevenLabsAdapter(Conversation, {
 })
 
 const liveKitAdapter = createLiveKitAdapter({
-  tokenSource: TokenSource.literal({
-    serverUrl: 'wss://example.livekit.cloud',
-    participantToken: 'livekit-token',
-  }),
-  createAudioAnalyser,
-  RoomClass: Room,
+  tokenEndpoint: '/api/livekit-token',
+  agentName: 'support-agent',
+})
+
+// @ts-expect-error LiveKit sandbox sessions must identify the agent to dispatch.
+createLiveKitAdapter({ sandboxId: 'sandbox-123' })
+
+// @ts-expect-error Choose a token endpoint or a sandbox, never both.
+createLiveKitAdapter({
+  tokenEndpoint: '/api/livekit-token',
+  sandboxId: 'sandbox-123',
+  agentName: 'support-agent',
 })
 
 const pipecatClient = new PipecatClient({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,11 +59,12 @@ export default defineConfig({
       entry: {
         'orb-ui': resolve(__dirname, 'src/index.ts'),
         adapters: resolve(__dirname, 'src/adapters/index.ts'),
+        'livekit-adapter': resolve(__dirname, 'src/adapters/livekit/browser.ts'),
       },
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      external: ['livekit-client', 'react', 'react-dom', 'react/jsx-runtime'],
     },
   },
 })


### PR DESCRIPTION
## Summary

- add a dedicated `orb-ui/adapters/livekit` browser entrypoint that owns the standard LiveKit `Room`, `TokenSource`, audio analysers, microphone lifecycle, and unique room naming
- reduce the recommended integration to `tokenEndpoint` plus an optional `agentName`
- support a similarly small `{ sandboxId, agentName }` testing path
- preserve the existing `orb-ui/adapters` LiveKit factory unchanged for app-owned Rooms, custom connection fetchers, raw credentials, token sources, and runtime overrides
- update the playground, README, docs, package examples, roadmap, and add a minor changeset

## User-facing API

```tsx
import { createLiveKitAdapter } from 'orb-ui/adapters/livekit'

const adapter = createLiveKitAdapter({
  tokenEndpoint: '/api/livekit-token',
  agentName: 'your-agent-name',
})
```

The adapter creates a fresh `orb-<uuid>` room name on each start. `agentName` may be omitted when the token endpoint already owns dispatch.

## Dependency and bundle behavior

- `livekit-client` is an optional peer and remains app-installed
- it is externalized from orb-ui's build
- the LiveKit-only entrypoint is approximately 1 kB gzip-independent wrapper code and is lazy-loaded in the playground
- importing `orb-ui/adapters` for another provider does not import `livekit-client`

## Verification

- `pnpm check`
- 37 unit tests across 8 files
- source, provider-example, emitted-package, and demo typechecks
- library and demo production builds
- 2 Chrome end-to-end package-consumer tests
- npm package dry run includes the new ESM/CJS entrypoint, declarations, and shared LiveKit core chunks
- focused tests cover endpoint defaults, sandbox mapping, invalid config unions, advanced API compatibility, and public export loading

## Compatibility

This is additive. Existing LiveKit imports from `orb-ui/adapters` continue to work without migration.
