### PR TITLE
feat!: remove legacy callback-object adapters

### DIFF
--- a/.changeset/friendly-signals-only.md
+++ b/.changeset/friendly-signals-only.md
@@ -1,0 +1,11 @@
+---
+'orb-ui': minor
+---
+
+BREAKING: Remove the deprecated callback-object adapter API scheduled for 0.5.0. `Orb` now accepts
+only signal-based adapters whose `subscribe(listener)` implementation emits complete `OrbSignal`
+objects. The `AdapterCallbacks` and `LegacyOrbAdapter` types are no longer exported.
+
+Migrate callbacks such as `onStateChange(state)` and `onVolumeChange(volume)` to
+`listener({ state, inputVolume, outputVolume })` calls. Provider adapters created by orb-ui already
+use the signal API and require no changes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@ Target direction:
 - Support `inputVolume` and `outputVolume`
 - Add a `thinking` voice state
 - Document migration from callback-object adapters
+- Remove callback-object adapter compatibility in 0.5.0
 - Remove surprising global audio behavior from `Orb`
 
 ### LiveKit adapter — complete

--- a/docs/reference/orb-component.mdx
+++ b/docs/reference/orb-component.mdx
@@ -76,7 +76,28 @@ Adapters normalize provider SDK events into orb-ui signals. If a provider is not
 <Orb signal={{ state: 'speaking', outputVolume: 0.72 }} />
 ```
 
-The older callback-object adapter shape still works with a deprecation warning, but new adapters should call `listener({ state, inputVolume, outputVolume })`.
+## Migrating callback-object adapters
+
+orb-ui 0.5.0 removes the deprecated callback-object adapter API. Pass one complete signal to the
+listener whenever state or volume changes.
+
+```ts
+// Before 0.5
+subscribe({ onStateChange, onVolumeChange }) {
+  session.on('state', onStateChange)
+  session.on('volume', onVolumeChange)
+}
+
+// 0.5.0+
+subscribe(listener) {
+  session.on('change', ({ state, inputVolume, outputVolume }) => {
+    listener({ state, inputVolume, outputVolume })
+  })
+}
+```
+
+Custom adapters should implement `OrbAdapter`; the removed `AdapterCallbacks` and
+`LegacyOrbAdapter` types are no longer exported.
 
 ## Related
 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -48,11 +48,4 @@ export {
   type OutputVolumeCalibrationSource,
   type OutputVolumeSample,
 } from './audio-level'
-export type {
-  AdapterCallbacks,
-  LegacyOrbAdapter,
-  OrbAdapter,
-  OrbSignal,
-  OrbSignalListener,
-  OrbState,
-} from './types'
+export type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from './types'

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,20 +1,11 @@
 import type {
-  AdapterCallbacks,
-  LegacyOrbAdapter,
   OrbAdapter,
   OrbSignal,
   OrbSignalListener,
   OrbState,
 } from '../components/Orb/Orb.types'
 
-export type {
-  AdapterCallbacks,
-  LegacyOrbAdapter,
-  OrbAdapter,
-  OrbSignal,
-  OrbSignalListener,
-  OrbState,
-}
+export type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState }
 
 /**
  * Shared mic volume curve — rescale real-world mic range to 0–1 with pow shaping

--- a/src/components/Orb/Orb.test.tsx
+++ b/src/components/Orb/Orb.test.tsx
@@ -1,8 +1,8 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import { Orb } from './Orb'
-import { createOrbSignalListener, deriveOrbState, deriveOrbVolume } from './signals'
-import type { LegacyOrbAdapter, OrbAdapter, OrbSignal } from './Orb.types'
+import { deriveOrbState, deriveOrbVolume } from './signals'
+import type { OrbAdapter, OrbSignal } from './Orb.types'
 
 function createAdapter(): OrbAdapter {
   return {
@@ -105,43 +105,5 @@ describe('Orb signal helpers', () => {
       0.3,
     )
     expect(deriveOrbVolume(0.4, 'speaking', adapterSignal)).toBe(0.4)
-  })
-
-  it('bridges legacy callback-object adapters into signals with one warning', () => {
-    const onSignal = vi.fn()
-    const warn = vi.fn()
-    let warned = false
-    const warnOnce = () => {
-      if (warned) return
-      warned = true
-      warn()
-    }
-    const listener = createOrbSignalListener(onSignal, warnOnce)
-
-    listener({ state: 'speaking', outputVolume: 0.6 })
-    listener.onStateChange('listening')
-    listener.onVolumeChange(0.35)
-
-    expect(onSignal).toHaveBeenNthCalledWith(1, { state: 'speaking', outputVolume: 0.6 })
-    expect(onSignal).toHaveBeenNthCalledWith(2, {
-      state: 'listening',
-      outputVolume: 0.6,
-    })
-    expect(onSignal).toHaveBeenNthCalledWith(3, {
-      state: 'listening',
-      outputVolume: 0.6,
-      volume: 0.35,
-    })
-    expect(warn).toHaveBeenCalledOnce()
-  })
-
-  it('accepts deprecated legacy adapters in Orb props', () => {
-    const legacyAdapter: LegacyOrbAdapter = {
-      subscribe: () => () => undefined,
-    }
-
-    const html = renderToStaticMarkup(<Orb adapter={legacyAdapter} theme="debug" />)
-
-    expect(html).toContain('ORB DEBUG')
   })
 })

--- a/src/components/Orb/Orb.tsx
+++ b/src/components/Orb/Orb.tsx
@@ -1,26 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { OrbProps, OrbSignal } from './Orb.types'
-import { createOrbSignalListener, deriveOrbState, deriveOrbVolume } from './signals'
+import { deriveOrbState, deriveOrbVolume } from './signals'
 import { DebugTheme } from '../../themes/debug'
 import { CircleTheme } from '../../themes/circle'
 import { BarsTheme } from '../../themes/bars'
-
-// ─── Orb component ────────────────────────────────────────────────────────────
-
-let legacyAdapterWarningShown = false
-
-function isProductionEnvironment() {
-  const globalProcess = (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process
-  return globalProcess?.env?.NODE_ENV === 'production'
-}
-
-function warnLegacyAdapter() {
-  if (legacyAdapterWarningShown || isProductionEnvironment()) return
-  legacyAdapterWarningShown = true
-  console.warn(
-    '[orb-ui] Callback-object adapters are deprecated. Use subscribe(listener) and emit OrbSignal objects instead. Legacy adapters will be removed in 0.5.0.',
-  )
-}
 
 export function Orb({
   signal: signalProp,
@@ -42,8 +25,7 @@ export function Orb({
     setAdapterSignal({ state: 'idle' })
 
     if (!adapter) return
-    const listener = createOrbSignalListener(setAdapterSignal, warnLegacyAdapter)
-    const unsubscribe = adapter.subscribe(listener)
+    const unsubscribe = adapter.subscribe(setAdapterSignal)
     return unsubscribe
   }, [adapter])
 

--- a/src/components/Orb/Orb.types.ts
+++ b/src/components/Orb/Orb.types.ts
@@ -28,19 +28,6 @@ export interface OrbAdapter {
   stop?: () => void | Promise<void>
 }
 
-/** @deprecated Use signal-based OrbAdapter.subscribe(listener). */
-export interface AdapterCallbacks {
-  onStateChange: (state: OrbState) => void
-  onVolumeChange: (volume: number) => void
-}
-
-/** @deprecated Callback-object adapters will be removed in 0.5.0. */
-export interface LegacyOrbAdapter {
-  subscribe(callbacks: AdapterCallbacks): () => void
-  start?: () => void | Promise<void>
-  stop?: () => void | Promise<void>
-}
-
 type DataAttributeValue = string | number | boolean | null | undefined
 
 export interface OrbHtmlAttributes extends AriaAttributes {
@@ -79,7 +66,7 @@ export interface OrbProps extends OrbHtmlAttributes {
    * Provider adapter (Vapi, ElevenLabs, etc.).
    * Handles signal updates automatically from the SDK.
    */
-  adapter?: OrbAdapter | LegacyOrbAdapter
+  adapter?: OrbAdapter
 
   /** Visual theme. Defaults to 'debug'. */
   theme?: OrbTheme

--- a/src/components/Orb/index.ts
+++ b/src/components/Orb/index.ts
@@ -1,7 +1,5 @@
 export { Orb } from './Orb'
 export type {
-  AdapterCallbacks,
-  LegacyOrbAdapter,
   OrbAdapter,
   OrbProps,
   OrbSignal,

--- a/src/components/Orb/signals.ts
+++ b/src/components/Orb/signals.ts
@@ -1,6 +1,4 @@
-import type { AdapterCallbacks, OrbSignal, OrbSignalListener, OrbState } from './Orb.types'
-
-export type HybridOrbSignalListener = OrbSignalListener & AdapterCallbacks
+import type { OrbSignal, OrbState } from './Orb.types'
 
 export function deriveOrbState(
   state: OrbState | undefined,
@@ -15,32 +13,4 @@ export function deriveOrbVolume(volume: number | undefined, state: OrbState, sig
   if (state === 'listening') return signal.inputVolume ?? signal.volume ?? 0
   if (state === 'speaking') return signal.outputVolume ?? signal.volume ?? 0
   return signal.volume ?? 0
-}
-
-export function createOrbSignalListener(
-  onSignal: OrbSignalListener,
-  onLegacyAdapterUsed: () => void,
-): HybridOrbSignalListener {
-  let currentSignal: OrbSignal = { state: 'idle' }
-
-  const emit = (nextSignal: OrbSignal) => {
-    currentSignal = nextSignal
-    onSignal(nextSignal)
-  }
-
-  const listener = ((signal: OrbSignal) => {
-    emit(signal)
-  }) as HybridOrbSignalListener
-
-  listener.onStateChange = (state) => {
-    onLegacyAdapterUsed()
-    emit({ ...currentSignal, state })
-  }
-
-  listener.onVolumeChange = (volume) => {
-    onLegacyAdapterUsed()
-    emit({ ...currentSignal, volume })
-  }
-
-  return listener
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 export { Orb } from './components/Orb'
 export type {
-  AdapterCallbacks,
-  LegacyOrbAdapter,
   OrbAdapter,
   OrbProps,
   OrbSignal,

--- a/tests/typecheck/provider-adapters.tsx
+++ b/tests/typecheck/provider-adapters.tsx
@@ -12,7 +12,11 @@ import {
   createVapiAdapter,
 } from '../../src/adapters'
 import { createLiveKitAdapter } from '../../src/adapters/livekit/browser'
-import type { LegacyOrbAdapter, OrbAdapter, OrbSignal } from '../../src/adapters'
+import type { OrbAdapter, OrbSignal } from '../../src/adapters'
+// @ts-expect-error AdapterCallbacks was removed in orb-ui 0.5.
+import type { AdapterCallbacks } from '../../src/adapters'
+// @ts-expect-error LegacyOrbAdapter was removed in orb-ui 0.5.
+import type { LegacyOrbAdapter } from '../../src/adapters'
 
 const vapi = new Vapi('public-key')
 const vapiAdapter = createVapiAdapter(vapi, {
@@ -76,13 +80,23 @@ const customSignalAdapter: OrbAdapter = {
   },
 }
 
-const legacyAdapter: LegacyOrbAdapter = {
-  subscribe(callbacks) {
+const callbackObjectAdapter = {
+  subscribe(callbacks: {
+    onStateChange(state: 'listening'): void
+    onVolumeChange(volume: number): void
+  }) {
     callbacks.onStateChange('listening')
     callbacks.onVolumeChange(0.4)
     return () => undefined
   },
 }
+
+// @ts-expect-error Callback-object adapters are not valid OrbAdapter implementations in 0.5.
+const removedCallbackObjectAdapter: OrbAdapter = callbackObjectAdapter
+
+void removedCallbackObjectAdapter
+void (undefined as unknown as AdapterCallbacks)
+void (undefined as unknown as LegacyOrbAdapter)
 
 const signal: OrbSignal = {
   state: 'speaking',
@@ -145,7 +159,6 @@ export function ProviderAdapterSmokeExamples() {
         aria-label="Start Gemini Live voice assistant"
       />
       <Orb adapter={customSignalAdapter} theme="circle" aria-label="Start custom voice assistant" />
-      <Orb adapter={legacyAdapter} theme="debug" />
       <Orb signal={signal} theme="circle" />
       <Orb state="listening" volume={0.4} theme="debug" id="controlled-orb" />
     </>


### PR DESCRIPTION
## Summary

- remove the deprecated callback-object adapter compatibility bridge scheduled for 0.5.0
- make `OrbProps.adapter` accept only signal-based `OrbAdapter` implementations
- stop exporting the removed `AdapterCallbacks` and `LegacyOrbAdapter` types
- add migration guidance, roadmap status, negative type coverage, and a minor changeset

## Migration

Custom adapters must call `listener({ state, inputVolume, outputVolume })` from `subscribe(listener)` instead of receiving separate `onStateChange` and `onVolumeChange` callbacks. All provider adapters shipped by orb-ui already use the signal API and need no changes.

## Verification

- `pnpm check`
- 35 unit tests across 8 files
- source, examples, emitted package, and demo typechecks
- library and demo production builds
- 2 Chrome package-consumer E2E tests
- package declarations inspected to confirm the legacy types are no longer emitted

## Authorship

Implemented and verified with OpenAI Codex from the task: remove the legacy callback-object adapter API before the 0.5.0 release.