### PR TITLE
feat: add cloud theme and external controls

### DIFF
--- a/.changeset/soft-clouds-breathe.md
+++ b/.changeset/soft-clouds-breathe.md
@@ -2,4 +2,4 @@
 'orb-ui': minor
 ---
 
-Add the atmospheric `cloud` theme and support passive adapter-backed visuals with external session controls through `interactive={false}`.
+Add the atmospheric `cloud` theme with a solid-dot-to-fluid entrance, state-paced cloud motion, and opposing input/output volume response. Support passive adapter-backed visuals with external session controls through `interactive={false}`.

--- a/.changeset/soft-clouds-breathe.md
+++ b/.changeset/soft-clouds-breathe.md
@@ -1,0 +1,5 @@
+---
+'orb-ui': minor
+---
+
+Add the atmospheric `cloud` theme and support passive adapter-backed visuals with external session controls through `interactive={false}`.

--- a/README.md
+++ b/README.md
@@ -225,32 +225,51 @@ function App() {
 }
 ```
 
+### External session controls
+
+Keep the orb as a passive visual when start and stop controls belong elsewhere in your layout.
+Provider adapters already expose the matching lifecycle methods.
+
+```jsx
+function VoiceExperience({ adapter }) {
+  return (
+    <>
+      <Orb adapter={adapter} theme="cloud" interactive={false} />
+      <button onClick={() => void adapter.start?.()}>Start conversation</button>
+      <button onClick={() => void adapter.stop?.()}>End conversation</button>
+    </>
+  )
+}
+```
+
 ## Themes
 
 | Theme    | Description                                                                   |
 | -------- | ----------------------------------------------------------------------------- |
+| `cloud`  | Atmospheric sphere with inverse listening scale and faster speaking motion.   |
 | `debug`  | State + volume display with start/stop. Use to verify your integration works. |
 | `circle` | Pulsing circle that reacts to volume.                                         |
 | `bars`   | Five bars that animate with voice.                                            |
 
-When an adapter or `onStart`/`onStop` handler is provided, `circle` and `bars` render as keyboard-accessible `<button type="button">` controls. Pass an `aria-label` when the surrounding UI does not already label the control.
+When an adapter or `onStart`/`onStop` handler is provided, visual themes render as keyboard-accessible `<button type="button">` controls. Pass `interactive={false}` to keep the theme passive and call `adapter.start()` or `adapter.stop()` from external controls instead.
 
 ## Props
 
-| Prop         | Type                            | Default   | Description                                                 |
-| ------------ | ------------------------------- | --------- | ----------------------------------------------------------- |
-| `theme`      | `'debug' \| 'circle' \| 'bars'` | `'debug'` | Visual theme                                                |
-| `signal`     | `OrbSignal`                     | —         | Rich controlled signal with state/input/output volume       |
-| `state`      | `OrbState`                      | `'idle'`  | Conversation state (controlled mode)                        |
-| `volume`     | `number`                        | `0`       | Audio volume, 0–1. Overrides signal/adapter volume.         |
-| `adapter`    | `OrbAdapter`                    | —         | Provider adapter (manages signal updates automatically)     |
-| `size`       | `number`                        | `200`     | Size in pixels                                              |
-| `className`  | `string`                        | —         | Optional class name for the rendered theme                  |
-| `style`      | `React.CSSProperties`           | —         | Optional inline styles for the rendered theme               |
-| `disabled`   | `boolean`                       | `false`   | Disables clickable themes and debug start/stop controls     |
-| `aria-label` | `string`                        | generated | Accessible label for clickable `circle` and `bars` controls |
-| `onStart`    | `() => void`                    | —         | Custom start handler (overrides adapter.start())            |
-| `onStop`     | `() => void`                    | —         | Custom stop handler (overrides adapter.stop())              |
+| Prop          | Type                                       | Default   | Description                                             |
+| ------------- | ------------------------------------------ | --------- | ------------------------------------------------------- |
+| `theme`       | `'debug' \| 'circle' \| 'bars' \| 'cloud'` | `'debug'` | Visual theme                                            |
+| `signal`      | `OrbSignal`                                | —         | Rich controlled signal with state/input/output volume   |
+| `state`       | `OrbState`                                 | `'idle'`  | Conversation state (controlled mode)                    |
+| `volume`      | `number`                                   | `0`       | Audio volume, 0–1. Overrides signal/adapter volume.     |
+| `adapter`     | `OrbAdapter`                               | —         | Provider adapter (manages signal updates automatically) |
+| `size`        | `number`                                   | `200`     | Size in pixels                                          |
+| `className`   | `string`                                   | —         | Optional class name for the rendered theme              |
+| `style`       | `React.CSSProperties`                      | —         | Optional inline styles for the rendered theme           |
+| `disabled`    | `boolean`                                  | `false`   | Disables clickable themes and debug start/stop controls |
+| `interactive` | `boolean`                                  | `true`    | Allows the orb itself to start and stop a session       |
+| `aria-label`  | `string`                                   | generated | Accessible label for clickable visual themes            |
+| `onStart`     | `() => void`                               | —         | Custom start handler (overrides adapter.start())        |
+| `onStop`      | `() => void`                               | —         | Custom stop handler (overrides adapter.stop())          |
 
 ## States
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,8 +52,9 @@ Add polished themes that feel production-ready, not just minimal examples. Publi
 
 Completed direction:
 
-- `cloud`: atmospheric blue-violet sphere with a compact connection entrance, opposing input/output
-  volume response, and passive external-control support
+- `cloud`: atmospheric blue-violet sphere with a solid-dot-to-fluid connection entrance,
+  state-paced internal cloud motion, opposing input/output volume response, and passive
+  external-control support
 
 Before naming another public theme, validate the visual direction against direct product UI research
 and a concrete interaction reference.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,12 +50,13 @@ token creation.
 
 Add polished themes that feel production-ready, not just minimal examples. Public API names should stay neutral and ownable.
 
-Candidate theme directions:
+Completed direction:
 
-- `halo`: luminous orb-style assistant presence
-- `prism`: colorful layered realtime voice presence
-- `studio`: waveform-forward voice interface
-- `aurora`: fluid multicolor assistant motion
+- `cloud`: atmospheric blue-violet sphere with a compact connection entrance, opposing input/output
+  volume response, and passive external-control support
+
+Before naming another public theme, validate the visual direction against direct product UI research
+and a concrete interaction reference.
 
 ### Better demo
 
@@ -65,6 +66,7 @@ Make the homepage demo feel like an actual product surface:
 - Live theme switching
 - Clear adapter examples
 - Better examples for provider and controlled modes
+- Separate session controls for passive visual themes
 
 ## Ongoing
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -5,7 +5,7 @@ import type { OrbSignal, OrbState, OrbTheme } from 'orb-ui'
 
 // Constants
 const STATES: OrbState[] = ['idle', 'connecting', 'listening', 'thinking', 'speaking', 'error']
-const THEMES: OrbTheme[] = ['circle', 'bars', 'debug']
+const THEMES: OrbTheme[] = ['cloud', 'circle', 'bars', 'debug']
 const GITHUB_REPO_URL = 'https://github.com/alexanderqchen/orb-ui'
 const GITHUB_STAR_COLOR = '#eab308'
 
@@ -18,6 +18,7 @@ type CodeTab =
   | 'openai'
   | 'gemini'
   | 'adapter'
+  | 'external'
   | 'controlled'
 
 interface SimulationStep {
@@ -26,7 +27,6 @@ interface SimulationStep {
 }
 
 const SIMULATION_STEPS: SimulationStep[] = [
-  { state: 'idle', duration: 1300 },
   { state: 'connecting', duration: 1000 },
   { state: 'listening', duration: 2600 },
   { state: 'thinking', duration: 900 },
@@ -34,6 +34,7 @@ const SIMULATION_STEPS: SimulationStep[] = [
 ]
 
 const SIMULATION_DURATION = SIMULATION_STEPS.reduce((total, step) => total + step.duration, 0)
+const IDLE_SIMULATION_FRAME = { state: 'idle' as OrbState, volume: 0 }
 const MONOSPACE_FONT =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
 
@@ -182,6 +183,18 @@ export function PreviewOrb() {
   return <Orb signal={signal} theme="circle" />
 }`
 
+const EXTERNAL_CONTROLS_CODE = `import { Orb } from "orb-ui"
+
+export function VoiceExperience({ adapter }) {
+  return (
+    <>
+      <Orb adapter={adapter} theme="cloud" interactive={false} />
+      <button onClick={() => void adapter.start?.()}>Start conversation</button>
+      <button onClick={() => void adapter.stop?.()}>End conversation</button>
+    </>
+  )
+}`
+
 function clamp(value: number, min = 0, max = 1) {
   return Math.min(max, Math.max(min, value))
 }
@@ -241,11 +254,14 @@ function signalFromStateVolume(state: OrbState, volume: number): OrbSignal {
   return { state, volume }
 }
 
-function useConversationSimulation() {
-  const [startedAt] = useState(() => nowMs())
-  const [frame, setFrame] = useState(() => getSimulationFrame(nowMs(), nowMs()))
+function useConversationSimulation(startedAt: number | null) {
+  const [frame, setFrame] = useState(() =>
+    startedAt === null ? IDLE_SIMULATION_FRAME : getSimulationFrame(startedAt, nowMs()),
+  )
 
   useEffect(() => {
+    if (startedAt === null) return
+
     let raf = 0
 
     const updateFrame = () => {
@@ -258,7 +274,7 @@ function useConversationSimulation() {
     return () => cancelAnimationFrame(raf)
   }, [startedAt])
 
-  return frame
+  return startedAt === null ? IDLE_SIMULATION_FRAME : frame
 }
 
 const NAV_LINKS = [
@@ -416,6 +432,8 @@ function codeForTab(tab: CodeTab) {
       return GEMINI_CODE
     case 'adapter':
       return ADAPTER_CODE
+    case 'external':
+      return EXTERNAL_CONTROLS_CODE
     case 'controlled':
       return CONTROLLED_CODE
     case 'vapi':
@@ -426,8 +444,9 @@ function codeForTab(tab: CodeTab) {
 
 // App
 export default function App() {
-  const simulation = useConversationSimulation()
-  const [theme, setTheme] = useState<OrbTheme>('circle')
+  const [simulationStartedAt, setSimulationStartedAt] = useState<number | null>(null)
+  const simulation = useConversationSimulation(simulationStartedAt)
+  const [theme, setTheme] = useState<OrbTheme>('cloud')
   const [mode, setMode] = useState<DemoMode>('simulation')
   const [sandboxState, setSandboxState] = useState<OrbState>('idle')
   const [sandboxVolume, setSandboxVolume] = useState(0)
@@ -656,6 +675,18 @@ export default function App() {
         >
           <Orb theme={theme} size={280} signal={activeOrb.signal} data-testid="orb-demo-visual" />
 
+          {mode === 'simulation' && (
+            <button
+              onClick={() =>
+                setSimulationStartedAt((current) => (current === null ? nowMs() : null))
+              }
+              style={{ ...btnStyle(false), marginTop: 16 }}
+              type="button"
+            >
+              {simulationStartedAt === null ? 'Start demo' : 'End demo'}
+            </button>
+          )}
+
           <div style={statusStripStyle}>
             <span data-testid="orb-demo-mode" style={statusCellStyle}>
               {activeOrb.mode}
@@ -775,6 +806,9 @@ export default function App() {
           </button>
           <button onClick={() => setCodeTab('adapter')} style={btnStyle(codeTab === 'adapter')}>
             Adapter
+          </button>
+          <button onClick={() => setCodeTab('external')} style={btnStyle(codeTab === 'external')}>
+            External controls
           </button>
           <button
             onClick={() => setCodeTab('controlled')}

--- a/demo/src/provider-playground.tsx
+++ b/demo/src/provider-playground.tsx
@@ -170,6 +170,14 @@ function normalizePipecatConnectionMode(value: unknown): PipecatConnectionMode {
   return value === 'small-webrtc' ? 'small-webrtc' : 'cloud'
 }
 
+function normalizeProvider(value: unknown): ProviderId {
+  return PROVIDERS.some((provider) => provider.id === value) ? (value as ProviderId) : 'manual'
+}
+
+function normalizeTheme(value: unknown): OrbTheme {
+  return THEMES.includes(value as OrbTheme) ? (value as OrbTheme) : 'circle'
+}
+
 function createLiveKitRoomName(prefix: string) {
   const normalizedPrefix = prefix || DEFAULT_LIVEKIT_ROOM_PREFIX
   const randomId =
@@ -264,9 +272,9 @@ function readStoredConfig(): Partial<ProviderConfig> {
     if (typeof parsed.liveKitServerUrl === 'string') {
       storedConfig.liveKitServerUrl = parsed.liveKitServerUrl
     }
-    if (typeof parsed.liveKitParticipantToken === 'string' && parsed.liveKitParticipantToken) {
+    if (typeof parsed.liveKitParticipantToken === 'string') {
       storedConfig.liveKitParticipantToken = parsed.liveKitParticipantToken
-    } else if (typeof parsed.liveKitToken === 'string' && parsed.liveKitToken) {
+    } else if (typeof parsed.liveKitToken === 'string') {
       storedConfig.liveKitParticipantToken = parsed.liveKitToken
     }
     if (typeof parsed.pipecatConnectionMode === 'string') {
@@ -277,14 +285,19 @@ function readStoredConfig(): Partial<ProviderConfig> {
     if (typeof parsed.pipecatAgentName === 'string') {
       storedConfig.pipecatAgentName = parsed.pipecatAgentName
     }
+    if (typeof parsed.pipecatApiKey === 'string') {
+      storedConfig.pipecatApiKey = parsed.pipecatApiKey
+    }
     if (typeof parsed.pipecatWebrtcUrl === 'string') {
       storedConfig.pipecatWebrtcUrl = parsed.pipecatWebrtcUrl
     }
+    if (typeof parsed.openAIApiKey === 'string') storedConfig.openAIApiKey = parsed.openAIApiKey
     if (typeof parsed.openAIModel === 'string') storedConfig.openAIModel = parsed.openAIModel
     if (typeof parsed.openAIVoice === 'string') storedConfig.openAIVoice = parsed.openAIVoice
     if (typeof parsed.openAIInstructions === 'string') {
       storedConfig.openAIInstructions = parsed.openAIInstructions
     }
+    if (typeof parsed.geminiApiKey === 'string') storedConfig.geminiApiKey = parsed.geminiApiKey
     if (typeof parsed.geminiModel === 'string') storedConfig.geminiModel = parsed.geminiModel
     if (typeof parsed.geminiVoice === 'string') storedConfig.geminiVoice = parsed.geminiVoice
     if (typeof parsed.geminiInstructions === 'string') {
@@ -297,17 +310,29 @@ function readStoredConfig(): Partial<ProviderConfig> {
   }
 }
 
-function writeStoredConfig(config: ProviderConfig) {
+function readStoredSelection(): { provider: ProviderId; theme: OrbTheme } {
+  const storage = getStorage()
+  if (!storage) return { provider: 'manual', theme: 'circle' }
+
+  try {
+    const parsed = JSON.parse(storage.getItem(CONFIG_STORAGE_KEY) ?? '{}')
+    if (!isRecord(parsed)) return { provider: 'manual', theme: 'circle' }
+
+    return {
+      provider: normalizeProvider(parsed.provider),
+      theme: normalizeTheme(parsed.theme),
+    }
+  } catch {
+    return { provider: 'manual', theme: 'circle' }
+  }
+}
+
+function writeStoredConfig(config: ProviderConfig, provider: ProviderId, theme: OrbTheme) {
   const storage = getStorage()
   if (!storage) return
 
   try {
-    const storedConfig: Partial<ProviderConfig> = { ...config }
-    delete storedConfig.liveKitParticipantToken
-    delete storedConfig.pipecatApiKey
-    delete storedConfig.openAIApiKey
-    delete storedConfig.geminiApiKey
-    storage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(storedConfig))
+    storage.setItem(CONFIG_STORAGE_KEY, JSON.stringify({ ...config, provider, theme }))
   } catch {
     // Storage can be disabled or full in some browser modes.
   }
@@ -862,8 +887,8 @@ function ProviderConfigFields({
           value={config.openAIInstructions}
         />
         <p className="provider-note">
-          The standard key is held in memory only and exchanged for a short-lived Realtime client
-          secret through this deployment.
+          The standard key is exchanged for a short-lived Realtime client secret through this
+          deployment.
         </p>
       </>
     )
@@ -898,8 +923,7 @@ function ProviderConfigFields({
           value={config.geminiInstructions}
         />
         <p className="provider-note">
-          The standard key is held in memory only and exchanged for a one-use Gemini Live token
-          through this deployment.
+          The standard key is exchanged for a one-use Gemini Live token through this deployment.
         </p>
       </>
     )
@@ -1053,8 +1077,9 @@ function ProviderReadinessRows({
 
 function ProviderPlayground() {
   const [config, setConfig] = useState<ProviderConfig>(() => readConfig())
-  const [provider, setProvider] = useState<ProviderId>('manual')
-  const [theme, setTheme] = useState<OrbTheme>('circle')
+  const [storedSelection] = useState(() => readStoredSelection())
+  const [provider, setProvider] = useState<ProviderId>(storedSelection.provider)
+  const [theme, setTheme] = useState<OrbTheme>(storedSelection.theme)
   const [manualState, setManualState] = useState<OrbState>('idle')
   const [manualInputVolume, setManualInputVolume] = useState(0.35)
   const [manualOutputVolume, setManualOutputVolume] = useState(0.65)
@@ -1068,8 +1093,8 @@ function ProviderPlayground() {
   const [peakRawOutput, setPeakRawOutput] = useState(0)
 
   useEffect(() => {
-    writeStoredConfig(config)
-  }, [config])
+    writeStoredConfig(config, provider, theme)
+  }, [config, provider, theme])
 
   useEffect(() => {
     outputCalibrationRef.current = outputCalibration
@@ -1534,6 +1559,10 @@ function ProviderPlayground() {
                     updateConfig={updateConfig}
                   />
                 </div>
+                <p className="provider-note">
+                  Configuration, including credentials, is saved in this browser for this exact
+                  playground URL. Use Clear to remove the current provider&apos;s saved values.
+                </p>
                 <div className="provider-config-actions">
                   <button className="provider-button" onClick={resetProviderConfig} type="button">
                     Use env defaults

--- a/demo/src/provider-playground.tsx
+++ b/demo/src/provider-playground.tsx
@@ -80,7 +80,7 @@ const PIPECAT_CONNECTION_MODES: Array<{ id: PipecatConnectionMode; label: string
   { id: 'small-webrtc', label: 'Self-hosted WebRTC' },
 ]
 
-const THEMES: OrbTheme[] = ['circle', 'bars', 'debug']
+const THEMES: OrbTheme[] = ['cloud', 'circle', 'bars', 'debug']
 const STATES: OrbState[] = ['idle', 'connecting', 'listening', 'thinking', 'speaking', 'error']
 const DEFAULT_LIVEKIT_ROOM_PREFIX = 'orb-ui-playground'
 const DEFAULT_OPENAI_MODEL = 'gpt-realtime-2.1'
@@ -1398,11 +1398,44 @@ function ProviderPlayground() {
                   aria-label={`Start ${provider} session`}
                   data-testid="provider-playground-orb"
                   disabled={!providerReady}
+                  interactive={theme !== 'cloud'}
                   size={280}
                   theme={theme}
                 />
               )}
             </div>
+
+            {provider !== 'manual' && theme === 'cloud' ? (
+              <div className="provider-controls">
+                <div className="provider-control-group">
+                  <span className="provider-label">External session controls</span>
+                  <div className="provider-segment">
+                    <button
+                      className="provider-button"
+                      disabled={
+                        !providerReady ||
+                        !monitoredAdapter?.start ||
+                        (activeState !== 'idle' && activeState !== 'error')
+                      }
+                      onClick={() => void monitoredAdapter?.start?.()}
+                      type="button"
+                    >
+                      Start
+                    </button>
+                    <button
+                      className="provider-button"
+                      disabled={
+                        !monitoredAdapter?.stop || activeState === 'idle' || activeState === 'error'
+                      }
+                      onClick={() => void monitoredAdapter?.stop?.()}
+                      type="button"
+                    >
+                      Stop
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ) : null}
 
             <div className="provider-status-strip">
               <div className="provider-status-item">

--- a/docs/examples/voice-orb-ui.mdx
+++ b/docs/examples/voice-orb-ui.mdx
@@ -34,6 +34,22 @@ export function ProviderOrb() {
 }
 ```
 
+## Passive orb with separate controls
+
+An orb can subscribe to an adapter without becoming the session control.
+
+```tsx
+export function VoiceSurface() {
+  return (
+    <>
+      <Orb adapter={adapter} theme="cloud" interactive={false} />
+      <button onClick={() => void adapter.start?.()}>Start conversation</button>
+      <button onClick={() => void adapter.stop?.()}>End conversation</button>
+    </>
+  )
+}
+```
+
 ## Custom controlled orb
 
 Use controlled mode when a custom stack supplies a voice signal.
@@ -48,6 +64,6 @@ export function CustomOrb({ voiceSignal }) {
 
 - Do not animate aggressively while idle.
 - Make listening and speaking visually distinct.
-- Use thinking for processing gaps between user input and assistant speech.
+- Use thinking for processing gaps when the selected theme benefits from a distinct treatment.
 - Keep error states obvious but not alarming.
 - Pair the orb with a transcript or status label when users need more precision.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -181,14 +181,32 @@ export function GeminiLiveVoiceUI() {
 See the [Gemini Live adapter guide](/adapters/gemini-live) for ephemeral token creation and the
 matching server-side activity-detection config.
 
+## External session controls
+
+Set `interactive={false}` when the orb should only display adapter state. Use the adapter's public
+lifecycle methods from controls placed elsewhere in your interface.
+
+```tsx
+export function VoiceExperience({ adapter }) {
+  return (
+    <>
+      <Orb adapter={adapter} theme="cloud" interactive={false} />
+      <button onClick={() => void adapter.start?.()}>Start conversation</button>
+      <button onClick={() => void adapter.stop?.()}>End conversation</button>
+    </>
+  )
+}
+```
+
 ## Themes
 
 Start with:
 
+- `cloud` for a soft atmospheric sphere with distinct listening and speaking motion.
 - `circle` for a primary assistant orb.
 - `bars` for waveform-like audio activity.
 - `debug` while verifying state and volume changes.
 
-Clickable `circle` and `bars` themes render as keyboard-accessible buttons when you provide an adapter or `onStart`/`onStop` handler. Add an `aria-label` if the surrounding UI does not already label the control.
+Visual themes render as keyboard-accessible buttons when you provide an adapter or `onStart`/`onStop` handler. Add an `aria-label` if the surrounding UI does not already label the control, or pass `interactive={false}` when a separate control owns the session lifecycle.
 
 Use the [voice states guide](/themes/voice-states) when you are deciding how each state should appear in your product.

--- a/docs/reference/orb-component.mdx
+++ b/docs/reference/orb-component.mdx
@@ -14,22 +14,23 @@ import { Orb } from 'orb-ui'
 
 ## Props
 
-| Prop         | Type                  | Default                | Description                                                        |
-| ------------ | --------------------- | ---------------------- | ------------------------------------------------------------------ |
-| `signal`     | `OrbSignal`           | adapter signal         | Current voice signal with state, input volume, and output volume.  |
-| `state`      | `OrbState`            | signal state or `idle` | Current voice agent state. Overrides signal and adapter state.     |
-| `volume`     | `number`              | signal volume or `0`   | Audio volume from `0` to `1`. Overrides signal and adapter volume. |
-| `adapter`    | `OrbAdapter`          | none                   | Provider adapter that subscribes to normalized signal updates.     |
-| `theme`      | `OrbTheme`            | `debug`                | Visual theme: `debug`, `circle`, or `bars`.                        |
-| `size`       | `number`              | `200`                  | Component size in pixels.                                          |
-| `className`  | `string`              | none                   | Optional class name for the rendered theme.                        |
-| `style`      | `React.CSSProperties` | none                   | Optional inline styles for the rendered theme.                     |
-| `disabled`   | `boolean`             | `false`                | Disables clickable themes and debug start/stop controls.           |
-| `id`         | `string`              | none                   | Forwarded to the rendered orb control/container.                   |
-| `data-*`     | `string`/primitive    | none                   | Forwarded to the rendered orb control/container, useful for tests. |
-| `aria-label` | `string`              | generated when needed  | Accessible label for clickable `circle` and `bars` controls.       |
-| `onStart`    | `() => void`          | adapter start          | Start handler used by the debug theme and clickable themes.        |
-| `onStop`     | `() => void`          | adapter stop           | Stop handler used by the debug theme and clickable themes.         |
+| Prop          | Type                  | Default                | Description                                                        |
+| ------------- | --------------------- | ---------------------- | ------------------------------------------------------------------ |
+| `signal`      | `OrbSignal`           | adapter signal         | Current voice signal with state, input volume, and output volume.  |
+| `state`       | `OrbState`            | signal state or `idle` | Current voice agent state. Overrides signal and adapter state.     |
+| `volume`      | `number`              | signal volume or `0`   | Audio volume from `0` to `1`. Overrides signal and adapter volume. |
+| `adapter`     | `OrbAdapter`          | none                   | Provider adapter that subscribes to normalized signal updates.     |
+| `theme`       | `OrbTheme`            | `debug`                | Visual theme: `debug`, `circle`, `bars`, or `cloud`.               |
+| `size`        | `number`              | `200`                  | Component size in pixels.                                          |
+| `className`   | `string`              | none                   | Optional class name for the rendered theme.                        |
+| `style`       | `React.CSSProperties` | none                   | Optional inline styles for the rendered theme.                     |
+| `disabled`    | `boolean`             | `false`                | Disables clickable themes and debug start/stop controls.           |
+| `interactive` | `boolean`             | `true`                 | Allows the orb itself to start and stop the session.               |
+| `id`          | `string`              | none                   | Forwarded to the rendered orb control/container.                   |
+| `data-*`      | `string`/primitive    | none                   | Forwarded to the rendered orb control/container, useful for tests. |
+| `aria-label`  | `string`              | generated when needed  | Accessible label for clickable visual themes.                      |
+| `onStart`     | `() => void`          | adapter start          | Start handler used by the debug theme and clickable themes.        |
+| `onStop`      | `() => void`          | adapter stop           | Stop handler used by the debug theme and clickable themes.         |
 
 ## States
 
@@ -42,14 +43,24 @@ Use these states consistently across providers so your product has one voice UI 
 ## Themes
 
 ```ts
-type OrbTheme = 'debug' | 'circle' | 'bars'
+type OrbTheme = 'debug' | 'circle' | 'bars' | 'cloud'
 ```
 
 - `debug`: visible state and start/stop controls while integrating.
 - `circle`: the primary animated voice orb.
 - `bars`: waveform-like audio activity.
+- `cloud`: a soft atmospheric sphere with opposing input/output scale response.
 
-When an adapter or `onStart`/`onStop` handler is provided, `circle` and `bars` render as `<button type="button">` controls with native keyboard activation. If there is no visible label, pass `aria-label`.
+When an adapter or `onStart`/`onStop` handler is provided, visual themes render as `<button type="button">` controls with native keyboard activation. If there is no visible label, pass `aria-label`.
+
+Set `interactive={false}` when the orb is only a visual status surface. The adapter remains the
+session controller, so external buttons can call its existing lifecycle methods.
+
+```tsx
+<Orb adapter={adapter} theme="cloud" interactive={false} />
+<button onClick={() => void adapter.start?.()}>Start conversation</button>
+<button onClick={() => void adapter.stop?.()}>End conversation</button>
+```
 
 ## Adapter interface
 

--- a/docs/themes/voice-states.mdx
+++ b/docs/themes/voice-states.mdx
@@ -7,6 +7,24 @@ description: Reference for orb-ui themes and voice agent states.
 
 orb-ui ships with a small set of themes for common voice agent UI needs.
 
+## Cloud
+
+Use `cloud` for a calm, atmospheric assistant presence. It keeps one blue-violet palette while
+communicating turn ownership through opposing scale and motion:
+
+- `connecting` shows a compact spinner before the sphere enters from a dot.
+- `listening` moves slowly and shrinks as input volume rises.
+- `speaking` grows with output volume and moves more quickly.
+- `thinking` reuses the calm neutral treatment instead of introducing another animation.
+- `idle` and `error` fade away when the visual is passive.
+
+```tsx
+<Orb adapter={adapter} theme="cloud" interactive={false} />
+```
+
+The passive form works well when microphone and end-session buttons live elsewhere in the product
+layout. Call `adapter.start()` and `adapter.stop()` from those controls.
+
 ## Circle
 
 Use `circle` when the voice agent is a primary assistant surface. It reads as an orb, status indicator, and voice presence at the same time.
@@ -41,5 +59,8 @@ Each state should answer a user question:
 - `thinking`: Is the assistant processing?
 - `speaking`: Is the assistant responding?
 - `error`: Did something fail?
+
+Themes do not need a unique treatment for every state. They may intentionally reuse a calm visual
+when another animation would add noise without improving comprehension.
 
 Keep motion calm during idle states and more responsive during active voice states. Audio-reactive movement should support comprehension, not compete with the transcript or controls.

--- a/src/components/Orb/Orb.test.tsx
+++ b/src/components/Orb/Orb.test.tsx
@@ -59,6 +59,13 @@ describe('Orb accessibility', () => {
     expect(html).not.toContain('<button')
   })
 
+  it('renders a solid launch layer before the cloud surface fades in', () => {
+    const html = renderToStaticMarkup(<Orb state="listening" theme="cloud" />)
+
+    expect(html).toContain('data-cloud-launch-dot=""')
+    expect(html).toContain('background:#5659dc')
+  })
+
   it('preserves consumer style overrides on clickable themes', () => {
     const html = renderToStaticMarkup(
       <Orb

--- a/src/components/Orb/Orb.test.tsx
+++ b/src/components/Orb/Orb.test.tsx
@@ -49,6 +49,16 @@ describe('Orb accessibility', () => {
     expect(html).not.toContain('<div')
   })
 
+  it('renders the cloud theme as a passive visual when interaction is external', () => {
+    const html = renderToStaticMarkup(
+      <Orb adapter={createAdapter()} theme="cloud" interactive={false} data-testid="cloud-orb" />,
+    )
+
+    expect(html).toContain('<canvas')
+    expect(html).toContain('data-testid="cloud-orb"')
+    expect(html).not.toContain('<button')
+  })
+
   it('preserves consumer style overrides on clickable themes', () => {
     const html = renderToStaticMarkup(
       <Orb
@@ -91,6 +101,7 @@ describe('Orb accessibility', () => {
     expect(renderToStaticMarkup(<Orb state="thinking" theme="debug" />)).toContain('thinking')
     expect(renderToStaticMarkup(<Orb state="thinking" theme="circle" />)).toContain('<div')
     expect(renderToStaticMarkup(<Orb state="thinking" theme="bars" />)).toContain('<div')
+    expect(renderToStaticMarkup(<Orb state="thinking" theme="cloud" />)).toContain('<canvas')
   })
 })
 

--- a/src/components/Orb/Orb.tsx
+++ b/src/components/Orb/Orb.tsx
@@ -4,6 +4,7 @@ import { deriveOrbState, deriveOrbVolume } from './signals'
 import { DebugTheme } from '../../themes/debug'
 import { CircleTheme } from '../../themes/circle'
 import { BarsTheme } from '../../themes/bars'
+import { CloudTheme } from '../../themes/cloud'
 
 export function Orb({
   signal: signalProp,
@@ -15,6 +16,7 @@ export function Orb({
   className,
   style,
   disabled = false,
+  interactive: interactiveProp = true,
   onStart,
   onStop,
   ...htmlProps
@@ -49,7 +51,8 @@ export function Orb({
 
   // Only render a clickable control when the current state can be handled.
   // Disabled controls stay semantic buttons but do not fire handlers.
-  const interactive = isActive ? !!(adapter?.stop || onStop) : !!(adapter?.start || onStart)
+  const canInteract = isActive ? !!(adapter?.stop || onStop) : !!(adapter?.start || onStart)
+  const interactive = interactiveProp && canInteract
   const clickHandler = interactive && !disabled ? handleClick : undefined
   const controlProps = {
     ...htmlProps,
@@ -78,13 +81,18 @@ export function Orb({
       return <CircleTheme {...interactiveThemeProps} onClick={clickHandler} />
     case 'bars':
       return <BarsTheme {...interactiveThemeProps} onClick={clickHandler} />
+    case 'cloud':
+      return <CloudTheme {...interactiveThemeProps} onClick={clickHandler} />
     case 'debug':
     default:
       return (
         <DebugTheme
           {...sharedThemeProps}
-          onStart={disabled ? undefined : (onStart ?? (() => adapter?.start?.()))}
-          onStop={disabled ? undefined : (onStop ?? (() => adapter?.stop?.()))}
+          disabled={disabled || !interactiveProp}
+          onStart={
+            disabled || !interactiveProp ? undefined : (onStart ?? (() => adapter?.start?.()))
+          }
+          onStop={disabled || !interactiveProp ? undefined : (onStop ?? (() => adapter?.stop?.()))}
         />
       )
   }

--- a/src/components/Orb/Orb.types.ts
+++ b/src/components/Orb/Orb.types.ts
@@ -2,7 +2,7 @@ import type { AriaAttributes, CSSProperties } from 'react'
 
 export type OrbState = 'idle' | 'connecting' | 'listening' | 'thinking' | 'speaking' | 'error'
 
-export type OrbTheme = 'debug' | 'circle' | 'bars'
+export type OrbTheme = 'debug' | 'circle' | 'bars' | 'cloud'
 
 export interface OrbSignal {
   state: OrbState
@@ -82,6 +82,12 @@ export interface OrbProps extends OrbHtmlAttributes {
 
   /** Disable clickable themes and debug start/stop controls. */
   disabled?: boolean
+
+  /**
+   * Allow the orb itself to start and stop an adapter-backed session.
+   * Set this to false when session controls live elsewhere in your UI.
+   */
+  interactive?: boolean
 
   /**
    * Called when a clickable theme is activated while idle/error.

--- a/src/themes/bars/BarsTheme.tsx
+++ b/src/themes/bars/BarsTheme.tsx
@@ -91,7 +91,7 @@ export function BarsTheme({
     })
 
     const updateHoverBoost = () => {
-      const canHover = true
+      const canHover = interactive && !disabled
       const target = hoveredRef.current && canHover ? hoverBoostMax : 0
       hoverBoostRef.current += (target - hoverBoostRef.current) * 0.15
     }
@@ -211,7 +211,7 @@ export function BarsTheme({
     <span
       ref={hoverRef}
       onMouseEnter={() => {
-        if (disabled) return
+        if (!interactive || disabled) return
         hoveredRef.current = true
         if (hoverRef.current) hoverRef.current.style.filter = 'brightness(1.35)'
       }}

--- a/src/themes/circle/CircleTheme.tsx
+++ b/src/themes/circle/CircleTheme.tsx
@@ -263,7 +263,7 @@ export function CircleTheme({
     <span
       ref={hoverRef}
       onMouseEnter={() => {
-        if (hoverRef.current && !disabled) {
+        if (hoverRef.current && interactive && !disabled) {
           hoverRef.current.style.transform = 'scale(1.06)'
           hoverRef.current.style.filter = 'brightness(1.12)'
         }

--- a/src/themes/cloud/CloudTheme.tsx
+++ b/src/themes/cloud/CloudTheme.tsx
@@ -98,13 +98,13 @@ void main() {
     0.46 +
     0.08 * sin((uv.x + warp.x * 0.2) * 5.4 + t * 0.42) +
     0.16 * (broad - 0.5);
-  float upper = smoothstep(horizon - 0.12, horizon + 0.15, uv.y);
+  float upper = smoothstep(horizon - 0.12, horizon + 0.08, uv.y);
   float band = exp(-pow((uv.y - horizon) * (5.2 + u_activity * 0.8), 2.0));
   float cloud = smoothstep(0.24, 0.79, field);
 
   vec3 deepPeriwinkle = vec3(0.36, 0.39, 0.985);
   vec3 upperPeriwinkle = vec3(0.48, 0.56, 0.985);
-  vec3 lowerLavender = vec3(0.79, 0.83, 0.985);
+  vec3 lowerLavender = vec3(0.72, 0.78, 0.975);
   vec3 milk = vec3(0.89, 0.92, 0.995);
 
   vec3 color = mix(lowerLavender, upperPeriwinkle, upper);

--- a/src/themes/cloud/CloudTheme.tsx
+++ b/src/themes/cloud/CloudTheme.tsx
@@ -95,7 +95,7 @@ void main() {
   float field = mix(broad, folded, 0.3 + u_activity * 0.14);
 
   float horizon =
-    0.50 +
+    0.46 +
     0.08 * sin((uv.x + warp.x * 0.2) * 5.4 + t * 0.42) +
     0.16 * (broad - 0.5);
   float upper = smoothstep(horizon - 0.12, horizon + 0.15, uv.y);
@@ -108,7 +108,7 @@ void main() {
   vec3 milk = vec3(0.89, 0.92, 0.995);
 
   vec3 color = mix(lowerLavender, upperPeriwinkle, upper);
-  float upperDepth = upper * smoothstep(0.48, 0.82, folded) * 0.42;
+  float upperDepth = upper * (0.14 + smoothstep(0.42, 0.78, folded) * 0.5);
   color = mix(color, deepPeriwinkle, upperDepth);
 
   float milkAmount = clamp(band * (0.42 + cloud * 0.62), 0.0, 0.88);
@@ -409,8 +409,8 @@ export function CloudTheme({
       let speed = 0.24
       let activity = 0.1
       if (nextState === 'listening') {
-        speed = 0.32 + currentVolume * 0.48
-        activity = 0.16 + currentVolume * 0.34
+        speed = 0.72 + currentVolume * 0.78
+        activity = 0.28 + currentVolume * 0.32
       } else if (nextState === 'speaking') {
         speed = 1.65 + currentVolume * 1.55
         activity = 0.66 + currentVolume * 0.34

--- a/src/themes/cloud/CloudTheme.tsx
+++ b/src/themes/cloud/CloudTheme.tsx
@@ -125,8 +125,8 @@ void main() {
 `
 
 const NEUTRAL_DIAMETER = 0.55
-const LISTEN_SHRINK = 0.136
-const SPEAK_GROW = 0.143
+const LISTEN_SHRINK = 0.204
+const SPEAK_GROW = 0.2145
 const DOT_SCALE = 0.063
 const LAUNCH_DOT_COLOR = '#5659dc'
 const ENTRANCE_OVERSHOOT = 1.178

--- a/src/themes/cloud/CloudTheme.tsx
+++ b/src/themes/cloud/CloudTheme.tsx
@@ -79,17 +79,24 @@ void main() {
   float t = u_time;
 
   vec2 warp = vec2(
-    fbm(p * 1.02 + vec2(t * 0.10, -t * 0.075)),
-    fbm(p * 1.08 + vec2(-t * 0.07, t * 0.09) + vec2(6.7, 2.9))
+    fbm(p * 1.02 + vec2(t * 0.34, -t * 0.24)),
+    fbm(p * 1.08 + vec2(-t * 0.27, t * 0.32) + vec2(6.7, 2.9))
   );
-  vec2 warped = p + (warp - 0.5) * (1.18 + u_activity * 0.24);
-  float broad = fbm(warped * 0.92 + vec2(t * 0.027, -t * 0.032));
-  float folded = fbm(warped * 1.66 + vec2(-t * 0.043, t * 0.036) + 5.2);
-  float field = mix(broad, folded, 0.3 + u_activity * 0.08);
+  vec2 curl = vec2(
+    sin(p.y * 2.4 + t * 0.68 + warp.y * 3.2),
+    cos(p.x * 2.1 - t * 0.61 + warp.x * 3.0)
+  );
+  vec2 warped =
+    p +
+    (warp - 0.5) * (1.18 + u_activity * 0.38) +
+    curl * (0.035 + u_activity * 0.07);
+  float broad = fbm(warped * 0.92 + vec2(t * 0.14, -t * 0.18));
+  float folded = fbm(warped * 1.66 + vec2(-t * 0.23, t * 0.19) + 5.2);
+  float field = mix(broad, folded, 0.3 + u_activity * 0.14);
 
   float horizon =
     0.50 +
-    0.08 * sin((uv.x + warp.x * 0.2) * 5.4 + t * 0.065) +
+    0.08 * sin((uv.x + warp.x * 0.2) * 5.4 + t * 0.42) +
     0.16 * (broad - 0.5);
   float upper = smoothstep(horizon - 0.12, horizon + 0.15, uv.y);
   float band = exp(-pow((uv.y - horizon) * (5.2 + u_activity * 0.8), 2.0));
@@ -121,10 +128,15 @@ const NEUTRAL_DIAMETER = 0.55
 const LISTEN_SHRINK = 0.136
 const SPEAK_GROW = 0.143
 const DOT_SCALE = 0.063
+const LAUNCH_DOT_COLOR = '#5659dc'
 const ENTRANCE_OVERSHOOT = 1.178
 const DOT_HOLD_MS = 180
 const GROW_MS = 300
 const SETTLE_MS = 1350
+const SURFACE_FADE_START_MS = DOT_HOLD_MS + GROW_MS * 0.22
+const SURFACE_FADE_END_MS = DOT_HOLD_MS + GROW_MS * 0.8
+const DOT_FADE_START_MS = DOT_HOLD_MS + GROW_MS * 0.58
+const DOT_FADE_END_MS = DOT_HOLD_MS + GROW_MS
 
 function clamp(value: number, min = 0, max = 1) {
   return Math.min(max, Math.max(min, value))
@@ -140,6 +152,11 @@ function easeOutCubic(value: number) {
 
 function mix(from: number, to: number, progress: number) {
   return from + (to - from) * progress
+}
+
+function smoothstepRange(value: number, start: number, end: number) {
+  const progress = clamp((value - start) / (end - start))
+  return progress * progress * (3 - 2 * progress)
 }
 
 function isVisibleState(state: OrbState) {
@@ -277,6 +294,7 @@ export function CloudTheme({
   ...controlProps
 }: CloudThemeProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const launchDotRef = useRef<HTMLSpanElement>(null)
   const spinnerRef = useRef<HTMLSpanElement>(null)
   const stateRef = useRef(state)
   const volumeRef = useRef(volume)
@@ -293,8 +311,9 @@ export function CloudTheme({
 
   useEffect(() => {
     const canvas = canvasRef.current
+    const launchDot = launchDotRef.current
     const spinner = spinnerRef.current
-    if (!canvas || !spinner) return
+    if (!canvas || !launchDot || !spinner) return
 
     const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
     const updateReducedMotion = () => {
@@ -361,11 +380,17 @@ export function CloudTheme({
       let scale = currentAudioScale * currentExitScale
       if (idleDot) scale = DOT_SCALE
 
+      let surfaceMix = idleDot ? 0 : 1
+      let launchDotOpacity = idleDot ? currentOpacity : 0
+
       if (visible && entranceStarted !== undefined && !reducedMotion) {
         const elapsed = now - entranceStarted
         const entrance = entranceScale(elapsed)
         const audioInfluence = clamp((elapsed - DOT_HOLD_MS - GROW_MS) / SETTLE_MS)
         scale = entrance * mix(1, currentAudioScale, audioInfluence)
+        surfaceMix = smoothstepRange(elapsed, SURFACE_FADE_START_MS, SURFACE_FADE_END_MS)
+        launchDotOpacity =
+          currentOpacity * (1 - smoothstepRange(elapsed, DOT_FADE_START_MS, DOT_FADE_END_MS))
         if (elapsed >= DOT_HOLD_MS + GROW_MS + SETTLE_MS) entranceStarted = undefined
       }
 
@@ -374,19 +399,21 @@ export function CloudTheme({
         ? spinnerTarget
         : damp(currentSpinnerOpacity, spinnerTarget, 18, deltaSeconds)
 
-      canvas.style.opacity = String(currentOpacity)
+      canvas.style.opacity = String(currentOpacity * surfaceMix)
       canvas.style.transform = `scale(${scale})`
+      launchDot.style.opacity = String(launchDotOpacity)
+      launchDot.style.transform = `scale(${scale})`
       spinner.style.opacity = String(currentSpinnerOpacity)
       spinner.style.transform = `rotate(${reducedMotion ? 45 : now * 0.34}deg)`
 
-      let speed = 0.14
-      let activity = 0.08
+      let speed = 0.24
+      let activity = 0.1
       if (nextState === 'listening') {
-        speed = 0.18 + currentVolume * 0.34
-        activity = 0.14 + currentVolume * 0.34
+        speed = 0.32 + currentVolume * 0.48
+        activity = 0.16 + currentVolume * 0.34
       } else if (nextState === 'speaking') {
-        speed = 0.82 + currentVolume * 0.84
-        activity = 0.52 + currentVolume * 0.44
+        speed = 1.65 + currentVolume * 1.55
+        activity = 0.66 + currentVolume * 0.34
       }
 
       if (!reducedMotion) flowTime += deltaSeconds * speed
@@ -426,6 +453,22 @@ export function CloudTheme({
         cursor: interactive ? (disabled ? 'not-allowed' : 'pointer') : 'default',
       }}
     >
+      <span
+        ref={launchDotRef}
+        data-cloud-launch-dot=""
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'block',
+          borderRadius: '50%',
+          background: LAUNCH_DOT_COLOR,
+          opacity: 0,
+          transform: `scale(${DOT_SCALE})`,
+          transformOrigin: 'center',
+          willChange: 'opacity, transform',
+        }}
+      />
       <canvas
         ref={canvasRef}
         aria-hidden="true"

--- a/src/themes/cloud/CloudTheme.tsx
+++ b/src/themes/cloud/CloudTheme.tsx
@@ -1,0 +1,501 @@
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import type { CSSProperties } from 'react'
+import type { OrbHtmlAttributes, OrbState } from '../../components/Orb/Orb.types'
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+interface CloudThemeProps extends OrbHtmlAttributes {
+  state: OrbState
+  volume: number
+  size: number
+  className?: string
+  style?: CSSProperties
+  disabled?: boolean
+  interactive?: boolean
+  onClick?: () => void
+}
+
+interface CloudRenderer {
+  draw(time: number, activity: number): void
+  destroy(): void
+}
+
+const VERTEX_SHADER = `
+attribute vec2 a_position;
+
+void main() {
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}
+`
+
+const FRAGMENT_SHADER = `
+precision highp float;
+
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform float u_activity;
+
+float hash(vec2 p) {
+  p = fract(p * vec2(123.34, 456.21));
+  p += dot(p, p + 45.32);
+  return fract(p.x * p.y);
+}
+
+float noise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+
+  return mix(
+    mix(hash(i), hash(i + vec2(1.0, 0.0)), u.x),
+    mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), u.x),
+    u.y
+  );
+}
+
+float fbm(vec2 p) {
+  float value = 0.0;
+  float amplitude = 0.52;
+  mat2 rotation = mat2(0.80, 0.60, -0.60, 0.80);
+
+  for (int octave = 0; octave < 5; octave++) {
+    value += amplitude * noise(p);
+    p = rotation * p * 1.92 + vec2(9.7, 4.3);
+    amplitude *= 0.5;
+  }
+
+  return value;
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / u_resolution;
+  vec2 centered = uv - 0.5;
+  float radius = length(centered);
+  float edge = 1.0 - smoothstep(0.488, 0.5, radius);
+
+  if (edge <= 0.0) discard;
+
+  vec2 p = centered * 2.0;
+  float t = u_time;
+
+  vec2 warp = vec2(
+    fbm(p * 1.02 + vec2(t * 0.10, -t * 0.075)),
+    fbm(p * 1.08 + vec2(-t * 0.07, t * 0.09) + vec2(6.7, 2.9))
+  );
+  vec2 warped = p + (warp - 0.5) * (1.18 + u_activity * 0.24);
+  float broad = fbm(warped * 0.92 + vec2(t * 0.027, -t * 0.032));
+  float folded = fbm(warped * 1.66 + vec2(-t * 0.043, t * 0.036) + 5.2);
+  float field = mix(broad, folded, 0.3 + u_activity * 0.08);
+
+  float horizon =
+    0.50 +
+    0.08 * sin((uv.x + warp.x * 0.2) * 5.4 + t * 0.065) +
+    0.16 * (broad - 0.5);
+  float upper = smoothstep(horizon - 0.12, horizon + 0.15, uv.y);
+  float band = exp(-pow((uv.y - horizon) * (5.2 + u_activity * 0.8), 2.0));
+  float cloud = smoothstep(0.24, 0.79, field);
+
+  vec3 deepPeriwinkle = vec3(0.36, 0.39, 0.985);
+  vec3 upperPeriwinkle = vec3(0.48, 0.56, 0.985);
+  vec3 lowerLavender = vec3(0.79, 0.83, 0.985);
+  vec3 milk = vec3(0.89, 0.92, 0.995);
+
+  vec3 color = mix(lowerLavender, upperPeriwinkle, upper);
+  float upperDepth = upper * smoothstep(0.48, 0.82, folded) * 0.42;
+  color = mix(color, deepPeriwinkle, upperDepth);
+
+  float milkAmount = clamp(band * (0.42 + cloud * 0.62), 0.0, 0.88);
+  color = mix(color, milk, milkAmount);
+
+  float lowerMist = (1.0 - upper) * smoothstep(0.58, 0.9, broad) * 0.18;
+  color = mix(color, milk, lowerMist);
+
+  float grain = (noise(gl_FragCoord.xy * 0.64) - 0.5) / 255.0;
+  color += grain;
+
+  gl_FragColor = vec4(color, edge);
+}
+`
+
+const NEUTRAL_DIAMETER = 0.55
+const LISTEN_SHRINK = 0.136
+const SPEAK_GROW = 0.143
+const DOT_SCALE = 0.063
+const ENTRANCE_OVERSHOOT = 1.178
+const DOT_HOLD_MS = 180
+const GROW_MS = 300
+const SETTLE_MS = 1350
+
+function clamp(value: number, min = 0, max = 1) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function damp(current: number, target: number, rate: number, deltaSeconds: number) {
+  return current + (target - current) * (1 - Math.exp(-rate * deltaSeconds))
+}
+
+function easeOutCubic(value: number) {
+  return 1 - Math.pow(1 - value, 3)
+}
+
+function mix(from: number, to: number, progress: number) {
+  return from + (to - from) * progress
+}
+
+function isVisibleState(state: OrbState) {
+  return state === 'listening' || state === 'speaking' || state === 'thinking'
+}
+
+function compileShader(
+  gl: WebGLRenderingContext,
+  type: number,
+  source: string,
+): WebGLShader | undefined {
+  const shader = gl.createShader(type)
+  if (!shader) return undefined
+
+  gl.shaderSource(shader, source)
+  gl.compileShader(shader)
+
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader)
+    return undefined
+  }
+
+  return shader
+}
+
+function createCloudRenderer(
+  canvas: HTMLCanvasElement,
+  diameter: number,
+): CloudRenderer | undefined {
+  const gl = canvas.getContext('webgl', {
+    alpha: true,
+    antialias: true,
+    premultipliedAlpha: true,
+  })
+  if (!gl) return undefined
+
+  const vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER)
+  const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER)
+  if (!vertexShader || !fragmentShader) {
+    if (vertexShader) gl.deleteShader(vertexShader)
+    if (fragmentShader) gl.deleteShader(fragmentShader)
+    return undefined
+  }
+
+  const program = gl.createProgram()
+  const buffer = gl.createBuffer()
+  if (!program || !buffer) {
+    if (program) gl.deleteProgram(program)
+    if (buffer) gl.deleteBuffer(buffer)
+    gl.deleteShader(vertexShader)
+    gl.deleteShader(fragmentShader)
+    return undefined
+  }
+
+  gl.attachShader(program, vertexShader)
+  gl.attachShader(program, fragmentShader)
+  gl.linkProgram(program)
+
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    gl.deleteProgram(program)
+    gl.deleteBuffer(buffer)
+    gl.deleteShader(vertexShader)
+    gl.deleteShader(fragmentShader)
+    return undefined
+  }
+
+  const positionLocation = gl.getAttribLocation(program, 'a_position')
+  const resolutionLocation = gl.getUniformLocation(program, 'u_resolution')
+  const timeLocation = gl.getUniformLocation(program, 'u_time')
+  const activityLocation = gl.getUniformLocation(program, 'u_activity')
+  if (positionLocation < 0 || !resolutionLocation || !timeLocation || !activityLocation) {
+    gl.deleteProgram(program)
+    gl.deleteBuffer(buffer)
+    gl.deleteShader(vertexShader)
+    gl.deleteShader(fragmentShader)
+    return undefined
+  }
+
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2)
+  const pixelSize = Math.max(1, Math.round(diameter * pixelRatio))
+  canvas.width = pixelSize
+  canvas.height = pixelSize
+
+  gl.viewport(0, 0, pixelSize, pixelSize)
+  gl.useProgram(program)
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer)
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]),
+    gl.STATIC_DRAW,
+  )
+  gl.enableVertexAttribArray(positionLocation)
+  gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0)
+  gl.uniform2f(resolutionLocation, pixelSize, pixelSize)
+
+  return {
+    draw(time, activity) {
+      gl.uniform1f(timeLocation, time)
+      gl.uniform1f(activityLocation, activity)
+      gl.drawArrays(gl.TRIANGLES, 0, 6)
+    },
+    destroy() {
+      gl.deleteProgram(program)
+      gl.deleteBuffer(buffer)
+      gl.deleteShader(vertexShader)
+      gl.deleteShader(fragmentShader)
+    },
+  }
+}
+
+function entranceScale(elapsed: number) {
+  if (elapsed <= DOT_HOLD_MS) return DOT_SCALE
+
+  if (elapsed <= DOT_HOLD_MS + GROW_MS) {
+    const progress = easeOutCubic((elapsed - DOT_HOLD_MS) / GROW_MS)
+    return mix(DOT_SCALE, ENTRANCE_OVERSHOOT, progress)
+  }
+
+  const settleElapsed = elapsed - DOT_HOLD_MS - GROW_MS
+  if (settleElapsed >= SETTLE_MS) return 1
+
+  const progress = clamp(settleElapsed / SETTLE_MS)
+  return 1 + (ENTRANCE_OVERSHOOT - 1) * Math.pow(1 - progress, 2)
+}
+
+export function CloudTheme({
+  state,
+  volume,
+  size,
+  className,
+  style,
+  disabled = false,
+  interactive = false,
+  onClick,
+  ...controlProps
+}: CloudThemeProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const spinnerRef = useRef<HTMLSpanElement>(null)
+  const stateRef = useRef(state)
+  const volumeRef = useRef(volume)
+  const interactiveRef = useRef(interactive)
+  const reducedMotionRef = useRef(false)
+
+  useIsomorphicLayoutEffect(() => {
+    stateRef.current = state
+    volumeRef.current = volume
+    interactiveRef.current = interactive
+  }, [interactive, state, volume])
+
+  const diameter = size * NEUTRAL_DIAMETER
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const spinner = spinnerRef.current
+    if (!canvas || !spinner) return
+
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const updateReducedMotion = () => {
+      reducedMotionRef.current = motionQuery.matches
+    }
+    updateReducedMotion()
+    motionQuery.addEventListener('change', updateReducedMotion)
+
+    const renderer = createCloudRenderer(canvas, diameter)
+    if (!renderer) {
+      canvas.style.background =
+        'linear-gradient(180deg, #626afb 2%, #8f9dfb 32%, #dde6fd 52%, #c9d3fb 84%)'
+    }
+
+    let frame = 0
+    let previousTime = performance.now()
+    let previousState = stateRef.current
+    let entranceStarted = isVisibleState(previousState) ? previousTime : undefined
+    let currentVolume = clamp(volumeRef.current)
+    let currentAudioScale = 1
+    let currentOpacity = isVisibleState(previousState) ? 1 : 0
+    let currentExitScale = 1
+    let currentSpinnerOpacity = previousState === 'connecting' ? 1 : 0
+    let flowTime = 0
+
+    const render = (now: number) => {
+      const deltaSeconds = Math.min((now - previousTime) / 1000, 0.05)
+      previousTime = now
+
+      const nextState = stateRef.current
+      const reducedMotion = reducedMotionRef.current
+
+      if (nextState !== previousState) {
+        if (isVisibleState(nextState) && !isVisibleState(previousState)) entranceStarted = now
+        if (nextState === 'idle' || nextState === 'error') entranceStarted = undefined
+        previousState = nextState
+      }
+
+      const rawVolume = clamp(volumeRef.current)
+      const volumeRate = rawVolume > currentVolume ? 11 : 6
+      currentVolume = reducedMotion ? 0 : damp(currentVolume, rawVolume, volumeRate, deltaSeconds)
+
+      let audioScaleTarget = 1
+      if (nextState === 'listening') audioScaleTarget = 1 - currentVolume * LISTEN_SHRINK
+      if (nextState === 'speaking') audioScaleTarget = 1 + currentVolume * SPEAK_GROW
+
+      const scaleRate = Math.abs(audioScaleTarget - 1) > Math.abs(currentAudioScale - 1) ? 12 : 6
+      currentAudioScale = reducedMotion
+        ? 1
+        : damp(currentAudioScale, audioScaleTarget, scaleRate, deltaSeconds)
+
+      const visible = isVisibleState(nextState)
+      const idleDot = nextState === 'idle' && interactiveRef.current
+      const canvasOpacityTarget = visible || idleDot ? 1 : 0
+      currentOpacity = reducedMotion
+        ? canvasOpacityTarget
+        : damp(currentOpacity, canvasOpacityTarget, 14, deltaSeconds)
+
+      const exitScaleTarget = visible || idleDot ? 1 : 0.92
+      currentExitScale = reducedMotion
+        ? exitScaleTarget
+        : damp(currentExitScale, exitScaleTarget, 12, deltaSeconds)
+
+      let scale = currentAudioScale * currentExitScale
+      if (idleDot) scale = DOT_SCALE
+
+      if (visible && entranceStarted !== undefined && !reducedMotion) {
+        const elapsed = now - entranceStarted
+        const entrance = entranceScale(elapsed)
+        const audioInfluence = clamp((elapsed - DOT_HOLD_MS - GROW_MS) / SETTLE_MS)
+        scale = entrance * mix(1, currentAudioScale, audioInfluence)
+        if (elapsed >= DOT_HOLD_MS + GROW_MS + SETTLE_MS) entranceStarted = undefined
+      }
+
+      const spinnerTarget = nextState === 'connecting' ? 1 : 0
+      currentSpinnerOpacity = reducedMotion
+        ? spinnerTarget
+        : damp(currentSpinnerOpacity, spinnerTarget, 18, deltaSeconds)
+
+      canvas.style.opacity = String(currentOpacity)
+      canvas.style.transform = `scale(${scale})`
+      spinner.style.opacity = String(currentSpinnerOpacity)
+      spinner.style.transform = `rotate(${reducedMotion ? 45 : now * 0.34}deg)`
+
+      let speed = 0.14
+      let activity = 0.08
+      if (nextState === 'listening') {
+        speed = 0.18 + currentVolume * 0.34
+        activity = 0.14 + currentVolume * 0.34
+      } else if (nextState === 'speaking') {
+        speed = 0.82 + currentVolume * 0.84
+        activity = 0.52 + currentVolume * 0.44
+      }
+
+      if (!reducedMotion) flowTime += deltaSeconds * speed
+      renderer?.draw(flowTime, activity)
+
+      frame = requestAnimationFrame(render)
+    }
+
+    frame = requestAnimationFrame(render)
+
+    return () => {
+      cancelAnimationFrame(frame)
+      motionQuery.removeEventListener('change', updateReducedMotion)
+      renderer?.destroy()
+    }
+  }, [diameter])
+
+  const rootStyle: CSSProperties = {
+    width: size,
+    height: size,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+    ...style,
+  }
+
+  const content = (
+    <span
+      style={{
+        position: 'relative',
+        display: 'block',
+        width: diameter,
+        height: diameter,
+        borderRadius: '50%',
+        lineHeight: 0,
+        cursor: interactive ? (disabled ? 'not-allowed' : 'pointer') : 'default',
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'block',
+          width: diameter,
+          height: diameter,
+          borderRadius: '50%',
+          opacity: 0,
+          transform: `scale(${DOT_SCALE})`,
+          transformOrigin: 'center',
+          willChange: 'opacity, transform',
+        }}
+      />
+      <span
+        ref={spinnerRef}
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: '50%',
+          width: diameter * 0.105,
+          height: diameter * 0.105,
+          boxSizing: 'border-box',
+          border: `${Math.max(1.5, diameter * 0.012)}px solid rgba(113, 120, 245, 0.24)`,
+          borderTopColor: '#777ff6',
+          borderRightColor: '#777ff6',
+          borderRadius: '50%',
+          opacity: 0,
+          transform: 'rotate(0deg)',
+          transformOrigin: 'center',
+          marginLeft: diameter * -0.0525,
+          marginTop: diameter * -0.0525,
+          willChange: 'opacity, transform',
+        }}
+      />
+    </span>
+  )
+
+  if (interactive) {
+    return (
+      <button
+        {...controlProps}
+        type="button"
+        className={className}
+        disabled={disabled}
+        onClick={disabled ? undefined : onClick}
+        style={{
+          appearance: 'none',
+          WebkitAppearance: 'none',
+          border: 0,
+          padding: 0,
+          margin: 0,
+          background: 'transparent',
+          color: 'inherit',
+          font: 'inherit',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          ...rootStyle,
+        }}
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return (
+    <div {...controlProps} className={className} style={rootStyle}>
+      {content}
+    </div>
+  )
+}

--- a/src/themes/cloud/index.ts
+++ b/src/themes/cloud/index.ts
@@ -1,0 +1,1 @@
+export { CloudTheme } from './CloudTheme'

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,3 +1,4 @@
 export { DebugTheme } from './debug'
 export { CircleTheme } from './circle'
 export { BarsTheme } from './bars'
+export { CloudTheme } from './cloud'

--- a/tests/e2e/fixture/main.tsx
+++ b/tests/e2e/fixture/main.tsx
@@ -68,6 +68,22 @@ function App() {
         />
         <output data-testid="controlled-output-volume">0.70</output>
       </section>
+
+      <section aria-label="External session controls">
+        <Orb
+          adapter={adapter}
+          data-testid="external-cloud-orb"
+          interactive={false}
+          size={160}
+          theme="cloud"
+        />
+        <button onClick={() => void adapter.start?.()} type="button">
+          Start externally
+        </button>
+        <button onClick={() => void adapter.stop?.()} type="button">
+          Stop externally
+        </button>
+      </section>
     </main>
   )
 }

--- a/tests/e2e/orb-consumer.spec.ts
+++ b/tests/e2e/orb-consumer.spec.ts
@@ -38,3 +38,19 @@ test('runs adapter start and stop through the rendered Orb', async ({ page }) =>
   await expect(page.getByTestId('adapter-input-volume')).toHaveText('0.00')
   expect(browserErrors).toEqual([])
 })
+
+test('supports passive visuals with external adapter controls', async ({ page }) => {
+  const browserErrors = collectBrowserErrors(page)
+
+  await page.goto('/')
+
+  await expect(page.getByTestId('external-cloud-orb')).toBeVisible()
+  await expect(page.getByTestId('external-cloud-orb')).toHaveJSProperty('tagName', 'DIV')
+
+  await page.getByRole('button', { name: 'Start externally' }).click()
+  await expect(page.getByTestId('adapter-state')).toHaveText('listening')
+
+  await page.getByRole('button', { name: 'Stop externally' }).click()
+  await expect(page.getByTestId('adapter-state')).toHaveText('idle')
+  expect(browserErrors).toEqual([])
+})

--- a/tests/package-typecheck/package-consumer.tsx
+++ b/tests/package-typecheck/package-consumer.tsx
@@ -107,6 +107,7 @@ export function PackageConsumerSmoke() {
       <Orb adapter={geminiLiveAdapter} theme="circle" aria-label="Start Gemini assistant" />
       <Orb adapter={customAdapter} theme="debug" />
       <Orb signal={signal} theme="circle" />
+      <Orb adapter={customAdapter} interactive={false} theme="cloud" />
     </>
   )
 }

--- a/tests/typecheck/provider-adapters.tsx
+++ b/tests/typecheck/provider-adapters.tsx
@@ -160,6 +160,7 @@ export function ProviderAdapterSmokeExamples() {
       />
       <Orb adapter={customSignalAdapter} theme="circle" aria-label="Start custom voice assistant" />
       <Orb signal={signal} theme="circle" />
+      <Orb adapter={customSignalAdapter} interactive={false} theme="cloud" />
       <Orb state="listening" volume={0.4} theme="debug" id="controlled-orb" />
     </>
   )


### PR DESCRIPTION
## Summary

- add a dependency-free atmospheric `cloud` theme with compact connection, spring entrance, calm listening, and audio-reactive speaking motion
- add `interactive={false}` so adapter-backed visuals can use session controls elsewhere in the layout
- persist playground provider configuration, credentials, selected provider, and selected theme per browser origin
- update the demo, provider playground, public docs, roadmap, type coverage, end-to-end coverage, and release changeset

## Why

Voice interfaces often separate the visual status surface from the button that starts or ends a session. This adds that composition pattern without introducing a second lifecycle API, while expanding the theme set with a polished active-voice treatment.

The QA playground also needs to remain ready across reloads on a stable preview alias, so provider configuration and the selected test surface now restore from local browser storage.

## Validation

- `pnpm check`
- live browser review across connecting, entrance, listening, speaking, idle, and error states
- manual provider review with Vapi, ElevenLabs, LiveKit, Pipecat, OpenAI Realtime, and Gemini Live
- Chrome reload verification for persisted provider, credential, theme, and enabled Start control
- no browser error overlay or application console warnings/errors

## Follow-up

LiveKit output-volume calibration and Pipecat input/output metering are adapter-level tuning items and are intentionally deferred to a separate PR.

## AI authorship

Implemented with Codex from product direction and interaction reference material supplied by the maintainer.