### PR TITLE
fix: calibrate LiveKit and Pipecat audio levels

### DIFF
--- a/.changeset/calm-orbs-listen.md
+++ b/.changeset/calm-orbs-listen.md
@@ -1,0 +1,5 @@
+---
+'orb-ui': patch
+---
+
+Keep LiveKit output volume dynamic with speech-oriented analyser settings and calibrated smoothing. Add Pipecat media-track metering so input and output volume remain available when transport audio-level events are missing or sparse, with live-tunable output calibration hooks for both adapters.

--- a/.changeset/calm-orbs-listen.md
+++ b/.changeset/calm-orbs-listen.md
@@ -2,4 +2,4 @@
 'orb-ui': patch
 ---
 
-Keep LiveKit output volume dynamic with speech-oriented analyser settings and calibrated smoothing. Add Pipecat media-track metering so input and output volume remain available when transport audio-level events are missing or sparse, with live-tunable output calibration hooks for both adapters.
+Keep LiveKit output volume dynamic with speech-oriented analyser settings and provider-tested calibration. Add Pipecat media-track metering so input and output volume remain available when transport audio-level events are missing or sparse, with provider-tested defaults and live-tunable output calibration hooks for both adapters.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ function App() {
 ```
 
 The LiveKit entrypoint creates the room and token source, assigns a fresh room name, and meters both
-sides of the conversation. Existing-room and custom-runtime modes remain available from the
-advanced `orb-ui/adapters` entrypoint.
+sides of the conversation with speech-oriented analyser and smoothing defaults. Existing-room and
+custom-runtime modes remain available from the advanced `orb-ui/adapters` entrypoint.
 
 ### With Pipecat
 
@@ -152,8 +152,9 @@ function App() {
 }
 ```
 
-The Pipecat adapter consumes the standard RTVI event surface, so it also works with Pipecat Cloud,
-Daily, and other Pipecat transports. See the [Pipecat guide](https://orb-ui.com/docs/adapters/pipecat).
+The Pipecat adapter consumes the standard RTVI event surface and meters the client media tracks as
+a browser fallback, so it works with Pipecat Cloud, Daily, SmallWebRTC, and transports that emit
+sparse audio-level events. See the [Pipecat guide](https://orb-ui.com/docs/adapters/pipecat).
 
 ### With OpenAI Realtime
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,13 +25,15 @@ volume metering, attached agent audio, and token-source based connection setup. 
 keep browser auth explicit by favoring token endpoints and LiveKit sandbox token servers over raw
 pasted participant tokens. The dedicated browser entrypoint owns the standard LiveKit SDK runtime,
 token source, and room naming so the normal setup only needs a token endpoint and optional agent
-name; advanced app-owned Room modes remain available separately.
+name; advanced app-owned Room modes remain available separately. Speech-oriented analyser ranges
+and output calibration hooks keep the normalized signal dynamic across normal agent voices.
 
 ### Pipecat adapter — complete
 
 The transport-agnostic Pipecat adapter consumes `PipecatClient` RTVI events and supports Pipecat
 Cloud/Daily, self-hosted SmallWebRTC, and custom client transports. It normalizes state and both
-audio levels while leaving agent deployment and connection credentials in the application.
+audio levels while leaving agent deployment and connection credentials in the application. Direct
+browser-track metering fills gaps when a transport does not emit frequent RTVI audio-level events.
 
 ### OpenAI Realtime adapter — complete
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,6 +71,20 @@ Make the homepage demo feel like an actual product surface:
 - Better examples for provider and controlled modes
 - Separate session controls for passive visual themes
 
+### Theme- and direction-aware calibration — future
+
+Provider adapters currently normalize audio into a portable `OrbSignal`, but one provider-wide
+curve cannot guarantee the same perceived motion across themes. Theme geometry and animation range
+change how a normalized level feels, while human input and agent output can also need different
+response profiles.
+
+Future calibration work should explore:
+
+- Independent input and output calibration profiles
+- Theme-level response mapping or presets layered on top of provider normalization
+- A playground matrix for comparing each provider, theme, and speaking direction
+- Keeping provider-specific measurement details out of theme implementations
+
 ## Ongoing
 
 - Keep docs search-friendly and implementation-honest

--- a/demo/src/provider-playground.tsx
+++ b/demo/src/provider-playground.tsx
@@ -21,7 +21,7 @@ import './provider-playground.css'
 type ProviderId = 'manual' | 'vapi' | 'elevenlabs' | 'livekit' | 'pipecat' | 'openai' | 'gemini'
 type LiveKitConnectionMode = 'sandbox' | 'endpoint' | 'raw'
 type PipecatConnectionMode = 'cloud' | 'small-webrtc'
-type TunableProviderId = 'openai' | 'gemini'
+type TunableProviderId = 'livekit' | 'pipecat' | 'openai' | 'gemini'
 type OutputCalibrationByProvider = Record<TunableProviderId, OutputVolumeCalibration>
 
 interface ProviderConfig {
@@ -94,6 +94,20 @@ const EMPTY_SIGNAL: OrbSignal = { state: 'idle', volume: 0, inputVolume: 0, outp
 const CONFIG_STORAGE_KEY = 'orb-ui:provider-playground-config'
 const CALIBRATION_STORAGE_KEY = 'orb-ui:provider-playground-output-calibration'
 const DEFAULT_OUTPUT_CALIBRATION: OutputCalibrationByProvider = {
+  livekit: {
+    noiseFloor: 0.015,
+    gain: 1.5,
+    exponent: 1.1,
+    attack: 0.28,
+    release: 0.08,
+  },
+  pipecat: {
+    noiseFloor: 0.002,
+    gain: 4,
+    exponent: 0.8,
+    attack: 0.6,
+    release: 0.2,
+  },
   openai: {
     noiseFloor: 0.003,
     gain: 4,
@@ -126,13 +140,20 @@ const OUTPUT_CALIBRATION_CONTROLS: Array<{
 ]
 
 function isTunableProvider(provider: ProviderId): provider is TunableProviderId {
-  return provider === 'openai' || provider === 'gemini'
+  return (
+    provider === 'livekit' ||
+    provider === 'pipecat' ||
+    provider === 'openai' ||
+    provider === 'gemini'
+  )
 }
 
 function copyOutputCalibration(
   calibration: OutputCalibrationByProvider,
 ): OutputCalibrationByProvider {
   return {
+    livekit: { ...calibration.livekit },
+    pipecat: { ...calibration.pipecat },
     openai: { ...calibration.openai },
     gemini: { ...calibration.gemini },
   }
@@ -207,7 +228,7 @@ function readStoredOutputCalibration(): OutputCalibrationByProvider {
     const parsed = JSON.parse(storage.getItem(CALIBRATION_STORAGE_KEY) ?? '{}')
     if (!isRecord(parsed)) return defaults
 
-    for (const provider of ['openai', 'gemini'] as const) {
+    for (const provider of ['livekit', 'pipecat', 'openai', 'gemini'] as const) {
       const storedProvider = parsed[provider]
       if (!isRecord(storedProvider)) continue
 
@@ -554,6 +575,8 @@ function createProviderAdapter(
       })
 
       return createPipecatAdapter(client, {
+        outputVolumeCalibration: outputCalibration?.get,
+        onOutputVolumeSample: outputCalibration?.onSample,
         connect:
           config.pipecatConnectionMode === 'cloud'
             ? () =>
@@ -626,6 +649,8 @@ function createProviderAdapter(
           sandboxId: config.liveKitSandboxId,
           agentName: config.liveKitAgentName,
           roomName: () => createLiveKitRoomName(config.liveKitRoomPrefix),
+          outputVolumeCalibration: outputCalibration?.get,
+          onOutputVolumeSample: outputCalibration?.onSample,
         })
       }
 
@@ -636,6 +661,8 @@ function createProviderAdapter(
           tokenEndpoint: config.liveKitTokenEndpoint,
           agentName: config.liveKitAgentName,
           roomName: () => createLiveKitRoomName(config.liveKitRoomPrefix),
+          outputVolumeCalibration: outputCalibration?.get,
+          onOutputVolumeSample: outputCalibration?.onSample,
         })
       }
 
@@ -645,6 +672,8 @@ function createProviderAdapter(
         participantToken: config.liveKitParticipantToken,
         createAudioAnalyser,
         RoomClass: Room,
+        outputVolumeCalibration: outputCalibration?.get,
+        onOutputVolumeSample: outputCalibration?.onSample,
       })
     })
   }

--- a/demo/src/provider-playground.tsx
+++ b/demo/src/provider-playground.tsx
@@ -96,17 +96,17 @@ const CALIBRATION_STORAGE_KEY = 'orb-ui:provider-playground-output-calibration'
 const DEFAULT_OUTPUT_CALIBRATION: OutputCalibrationByProvider = {
   livekit: {
     noiseFloor: 0.015,
-    gain: 1.5,
-    exponent: 1.1,
-    attack: 0.28,
-    release: 0.08,
+    gain: 4.6,
+    exponent: 1.15,
+    attack: 0.1,
+    release: 0.48,
   },
   pipecat: {
     noiseFloor: 0.002,
-    gain: 4,
+    gain: 5.1,
     exponent: 0.8,
-    attack: 0.6,
-    release: 0.2,
+    attack: 0.5,
+    release: 0.22,
   },
   openai: {
     noiseFloor: 0.003,

--- a/docs/adapters/livekit.mdx
+++ b/docs/adapters/livekit.mdx
@@ -155,10 +155,11 @@ retains word-level movement instead of staying near one level.
 
 ## Output calibration
 
-The default output curve is tuned against a real LiveKit agent session for pronounced word-level
-movement without pinning the signal at maximum. Most applications should use it unchanged. For
-diagnostics or an unusual audio mix, pass a partial `outputVolumeCalibration` object, or a getter
-when controls need to update during a live session:
+The default output curve is tuned against a real LiveKit agent session using the `cloud` theme for
+pronounced word-level movement without pinning the signal at maximum. It is a provider baseline,
+not a guarantee that every theme will feel identical. For a different theme or unusual audio mix,
+pass a partial `outputVolumeCalibration` object, or a getter when controls need to update during a
+live session:
 
 ```tsx
 const adapter = createLiveKitAdapter({

--- a/docs/adapters/livekit.mdx
+++ b/docs/adapters/livekit.mdx
@@ -149,7 +149,28 @@ LiveKit remote agent audio is attached when available. The recommended browser e
 the SDK audio analysers automatically: the local microphone emits normalized `inputVolume` while
 the agent is listening, and remote agent audio emits normalized `outputVolume` while the agent is
 speaking. The shared `volume` value follows whichever side is active so every orb-ui theme reacts
-correctly.
+correctly. The adapter supplies a speech-oriented decibel range to LiveKit's analyser instead of
+using its narrow defaults, then applies independent attack and release smoothing so normal speech
+retains word-level movement instead of staying near one level.
+
+## Output calibration
+
+The default output curve is tuned for LiveKit's browser analyser. Most applications should use it
+unchanged. For diagnostics or an unusual audio mix, pass a partial `outputVolumeCalibration`
+object, or a getter when controls need to update during a live session:
+
+```tsx
+const adapter = createLiveKitAdapter({
+  tokenEndpoint: '/api/livekit-token',
+  agentName: 'your-agent-name',
+  outputVolumeCalibration: {
+    release: 0.12,
+  },
+  onOutputVolumeSample: ({ raw, shaped, normalized }) => {
+    console.debug({ raw, shaped, normalized })
+  },
+})
+```
 
 ## Token handling
 

--- a/docs/adapters/livekit.mdx
+++ b/docs/adapters/livekit.mdx
@@ -155,9 +155,10 @@ retains word-level movement instead of staying near one level.
 
 ## Output calibration
 
-The default output curve is tuned for LiveKit's browser analyser. Most applications should use it
-unchanged. For diagnostics or an unusual audio mix, pass a partial `outputVolumeCalibration`
-object, or a getter when controls need to update during a live session:
+The default output curve is tuned against a real LiveKit agent session for pronounced word-level
+movement without pinning the signal at maximum. Most applications should use it unchanged. For
+diagnostics or an unusual audio mix, pass a partial `outputVolumeCalibration` object, or a getter
+when controls need to update during a live session:
 
 ```tsx
 const adapter = createLiveKitAdapter({

--- a/docs/adapters/pipecat.mdx
+++ b/docs/adapters/pipecat.mdx
@@ -105,9 +105,9 @@ multi-participant session, or set `playRemoteAudio: false` when your app owns pl
 
 ## Output calibration
 
-The default output curve is tuned against a real Pipecat Cloud agent session and works for both
-RTVI gain events and browser-track RMS samples. Override a partial value only when a particular
-transport or audio mix needs different shaping:
+The default output curve is tuned against a real Pipecat Cloud agent session using the `cloud`
+theme and works for both RTVI gain events and browser-track RMS samples. It is a provider baseline,
+so a different theme, transport, or audio mix may benefit from a partial override:
 
 ```tsx
 const adapter = createPipecatAdapter(client, {

--- a/docs/adapters/pipecat.mdx
+++ b/docs/adapters/pipecat.mdx
@@ -97,9 +97,32 @@ export function PipecatVoiceUI() {
 - disconnected -> `idle`
 
 RTVI `LocalAudioLevel` becomes `inputVolume`; bot `RemoteAudioLevel` becomes `outputVolume`. The
-adapter shapes Pipecat's typically low raw gain values so both sides remain visually responsive and
+adapter also meters the `PipecatClient` local and bot `MediaStreamTrack` values directly when they
+are available. That browser fallback keeps both levels working with SmallWebRTC and with transports
+whose RTVI level events are unavailable or sparse. The adapter shapes low raw gain values and
 attaches remote bot audio tracks automatically. Use `isBotParticipant` to filter audio in a
 multi-participant session, or set `playRemoteAudio: false` when your app owns playback.
+
+## Output calibration
+
+The default output curve works for both RTVI gain events and browser-track RMS samples. Override a
+partial value only when a particular transport or audio mix needs different shaping:
+
+```tsx
+const adapter = createPipecatAdapter(client, {
+  connect,
+  outputVolumeCalibration: {
+    gain: 3.5,
+  },
+  onOutputVolumeSample: ({ raw, shaped, normalized }) => {
+    console.debug({ raw, shaped, normalized })
+  },
+})
+```
+
+Pass a getter instead of an object to tune the values while a session is active. Set
+`createAudioContext` to a custom factory—or return `undefined`—when your runtime needs to own or
+disable browser-track metering.
 
 ## Custom session startup
 

--- a/docs/adapters/pipecat.mdx
+++ b/docs/adapters/pipecat.mdx
@@ -105,8 +105,9 @@ multi-participant session, or set `playRemoteAudio: false` when your app owns pl
 
 ## Output calibration
 
-The default output curve works for both RTVI gain events and browser-track RMS samples. Override a
-partial value only when a particular transport or audio mix needs different shaping:
+The default output curve is tuned against a real Pipecat Cloud agent session and works for both
+RTVI gain events and browser-track RMS samples. Override a partial value only when a particular
+transport or audio mix needs different shaping:
 
 ```tsx
 const adapter = createPipecatAdapter(client, {

--- a/src/adapters/audio-level.ts
+++ b/src/adapters/audio-level.ts
@@ -24,6 +24,12 @@ export interface OutputVolumeSample {
   normalized: number
 }
 
+export interface MediaStreamTrackVolumeMeter {
+  stop(): Promise<void>
+}
+
+export type AudioContextSource = () => AudioContext | undefined
+
 export const DEFAULT_OUTPUT_VOLUME_CALIBRATION: OutputVolumeCalibration = {
   noiseFloor: 0,
   gain: 4,
@@ -74,4 +80,48 @@ export function calibrateOutputVolume(
   const normalized = clamp(previous + (shaped - previous) * rate, 0, 1)
 
   return { raw, shaped, normalized }
+}
+
+export function createMediaStreamTrackVolumeMeter(
+  track: MediaStreamTrack,
+  createAudioContext: AudioContextSource,
+  onVolume: (volume: number) => void,
+): MediaStreamTrackVolumeMeter | undefined {
+  let context: AudioContext | undefined
+
+  try {
+    context = createAudioContext()
+    if (!context) return undefined
+    const activeContext = context
+    if (activeContext.state === 'suspended') void activeContext.resume().catch(() => undefined)
+
+    const source = activeContext.createMediaStreamSource(new MediaStream([track]))
+    const analyser = activeContext.createAnalyser()
+    analyser.fftSize = 512
+    analyser.smoothingTimeConstant = 0.25
+    source.connect(analyser)
+
+    const samples = new Float32Array(analyser.fftSize)
+    const interval = setInterval(() => {
+      analyser.getFloatTimeDomainData(samples)
+      let sumSquares = 0
+      for (const sample of samples) sumSquares += sample * sample
+      onVolume(Math.sqrt(sumSquares / samples.length))
+    }, 33)
+
+    return {
+      async stop() {
+        clearInterval(interval)
+        try {
+          source.disconnect()
+          analyser.disconnect()
+        } finally {
+          if (activeContext.state !== 'closed') await activeContext.close()
+        }
+      },
+    }
+  } catch {
+    if (context?.state !== 'closed') void context?.close().catch(() => undefined)
+    return undefined
+  }
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -26,6 +26,7 @@ export {
   type PipecatClientLike,
   type PipecatOrbAdapter,
   type PipecatParticipantLike,
+  type PipecatTracksLike,
 } from './pipecat'
 export {
   createOpenAIRealtimeAdapter,

--- a/src/adapters/livekit/browser.test.ts
+++ b/src/adapters/livekit/browser.test.ts
@@ -56,6 +56,8 @@ describe('managed LiveKit browser adapter', () => {
   it('creates sandbox adapters and forwards optional token values', () => {
     const roomName = () => 'custom-room'
     const participantAttributes = () => ({ plan: 'test' })
+    const outputVolumeCalibration = () => ({ gain: 1.25 })
+    const onOutputVolumeSample = vi.fn()
 
     createLiveKitAdapter({
       sandboxId: 'sandbox-123',
@@ -64,6 +66,8 @@ describe('managed LiveKit browser adapter', () => {
       roomName,
       participantAttributes,
       enableMicrophone: false,
+      outputVolumeCalibration,
+      onOutputVolumeSample,
     })
 
     expect(mocks.sandboxTokenServer).toHaveBeenCalledWith('sandbox-123', {
@@ -72,6 +76,8 @@ describe('managed LiveKit browser adapter', () => {
     expect(mocks.createAdvancedLiveKitAdapter).toHaveBeenCalledWith(
       expect.objectContaining({
         enableMicrophone: false,
+        outputVolumeCalibration,
+        onOutputVolumeSample,
         tokenOptions: expect.objectContaining({
           agentName: 'test-agent',
           roomName,

--- a/src/adapters/livekit/browser.ts
+++ b/src/adapters/livekit/browser.ts
@@ -4,6 +4,7 @@ import {
   type LiveKitOrbAdapter,
   type LiveKitTokenOptions,
 } from './index'
+import type { OutputVolumeCalibrationSource, OutputVolumeSample } from '../audio-level'
 
 interface LiveKitBrowserAdapterBase extends Omit<LiveKitTokenOptions, 'agentName' | 'roomName'> {
   /** Agent dispatched into the room. Required for LiveKit Cloud sandbox sessions. */
@@ -14,6 +15,10 @@ interface LiveKitBrowserAdapterBase extends Omit<LiveKitTokenOptions, 'agentName
   connectOptions?: Record<string, unknown>
   /** Enable the local microphone after connecting. Defaults to true. */
   enableMicrophone?: boolean
+  /** Optional live-tunable output shaping. A getter is read for every meter sample. */
+  outputVolumeCalibration?: OutputVolumeCalibrationSource
+  /** Receives raw, shaped, and smoothed output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: OutputVolumeSample) => void
 }
 
 export type LiveKitTokenEndpointOptions = Omit<RequestInit, 'body'>
@@ -70,6 +75,8 @@ export function createLiveKitAdapter(config: LiveKitBrowserAdapterConfig): LiveK
     participantMetadata,
     participantName,
     roomName = createRoomName,
+    outputVolumeCalibration,
+    onOutputVolumeSample,
   } = config
 
   const tokenSource =
@@ -91,6 +98,8 @@ export function createLiveKitAdapter(config: LiveKitBrowserAdapterConfig): LiveK
     },
     connectOptions,
     enableMicrophone,
+    outputVolumeCalibration,
+    onOutputVolumeSample,
     createAudioAnalyser,
     RoomClass: Room,
   }) as LiveKitOrbAdapter

--- a/src/adapters/livekit/index.test.ts
+++ b/src/adapters/livekit/index.test.ts
@@ -171,6 +171,51 @@ describe('createLiveKitAdapter', () => {
     unsubscribe()
   })
 
+  it('keeps remote speech dynamic instead of flattening analyser output near maximum', () => {
+    vi.useFakeTimers()
+    createDocumentStub()
+    const track = new FakeTrack()
+    const room = new FakeRoom()
+    room.state = 'connected'
+    room.remoteParticipants.set(
+      'agent',
+      new FakeParticipant({
+        attributes: { 'lk.agent.state': 'speaking' },
+        kind: 4,
+        track,
+      }),
+    )
+
+    const rawLevels = [0.05, 0.25, 0.1, 0]
+    const onOutputVolumeSample = vi.fn()
+    const adapter = createLiveKitAdapter({
+      room,
+      createAudioAnalyser: () => ({
+        calculateVolume: () => rawLevels.shift() ?? 0,
+        cleanup: async () => undefined,
+      }),
+      onOutputVolumeSample,
+    })
+    const { signals, unsubscribe } = collectSignals(adapter)
+    const outputLevels: number[] = []
+
+    for (let index = 0; index < 4; index += 1) {
+      vi.advanceTimersByTime(33)
+      outputLevels.push(signals.at(-1)?.outputVolume ?? 0)
+    }
+
+    expect(outputLevels[0]).toBeGreaterThan(0)
+    expect(outputLevels[1]).toBeGreaterThan(outputLevels[0])
+    expect(outputLevels[1]).toBeLessThan(0.5)
+    expect(outputLevels[3]).toBeLessThan(outputLevels[1])
+    expect(onOutputVolumeSample).toHaveBeenCalledTimes(4)
+    expect(onOutputVolumeSample.mock.calls.map(([sample]) => sample.raw)).toEqual([
+      0.05, 0.25, 0.1, 0,
+    ])
+
+    unsubscribe()
+  })
+
   it('subscribes to an existing room and emits agent signal and output volume', () => {
     vi.useFakeTimers()
     const { appendChild } = createDocumentStub()
@@ -289,7 +334,12 @@ describe('createLiveKitAdapter', () => {
       undefined,
     )
     expect(RoomClass.instance?.localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true)
-    expect(createAudioAnalyser).toHaveBeenCalledWith(localTrack)
+    expect(createAudioAnalyser).toHaveBeenCalledWith(localTrack, {
+      fftSize: 512,
+      smoothingTimeConstant: 0.25,
+      minDecibels: -85,
+      maxDecibels: -20,
+    })
     expect(signals.some((signal) => signal.state === 'connecting')).toBe(true)
     expect(RoomClass.instance?.listenerCount('participantAttributesChanged')).toBe(1)
 

--- a/src/adapters/livekit/index.ts
+++ b/src/adapters/livekit/index.ts
@@ -1,5 +1,11 @@
 import { normalizeMicVolume } from '../types'
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
+import { calibrateOutputVolume } from '../audio-level'
+import type {
+  OutputVolumeCalibration,
+  OutputVolumeCalibrationSource,
+  OutputVolumeSample,
+} from '../audio-level'
 
 // Minimal LiveKit interfaces. orb-ui does not import livekit-client directly so
 // the SDK remains an app-owned dependency.
@@ -88,11 +94,20 @@ export interface LiveKitTokenSource {
 /** Agent participant kind value from LiveKit protocol (ParticipantKind.AGENT). */
 const LK_PARTICIPANT_KIND_AGENT = 4
 
-const NOISE_FLOOR = 0.03
-const OUTPUT_GAIN = 1.5
-const EMA_ATTACK = 0.6
-const EMA_RELEASE = 0.2
-const SIGMOID_K = 0.35
+const LIVEKIT_ANALYSER_OPTIONS = {
+  fftSize: 512,
+  smoothingTimeConstant: 0.25,
+  minDecibels: -85,
+  maxDecibels: -20,
+}
+
+const DEFAULT_LIVEKIT_OUTPUT_CALIBRATION: OutputVolumeCalibration = {
+  noiseFloor: 0.015,
+  gain: 1.5,
+  exponent: 1.1,
+  attack: 0.28,
+  release: 0.08,
+}
 
 function mapAgentState(lkState: string): OrbState {
   switch (lkState) {
@@ -116,7 +131,14 @@ function mapAgentState(lkState: string): OrbState {
   }
 }
 
-interface LiveKitManagedBaseConfig<TTrack = unknown> {
+interface LiveKitVolumeConfig {
+  /** Optional live-tunable output shaping. A getter is read for every meter sample. */
+  outputVolumeCalibration?: OutputVolumeCalibrationSource
+  /** Receives raw, shaped, and smoothed output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: OutputVolumeSample) => void
+}
+
+interface LiveKitManagedBaseConfig<TTrack = unknown> extends LiveKitVolumeConfig {
   /** The createAudioAnalyser function from livekit-client. */
   createAudioAnalyser: LKCreateAudioAnalyser<TTrack>
   /** The Room constructor from livekit-client. */
@@ -130,7 +152,7 @@ interface LiveKitManagedBaseConfig<TTrack = unknown> {
 }
 
 /** App-managed mode: subscribe to a pre-existing Room. */
-interface LiveKitRoomConfig<TTrack = unknown> {
+interface LiveKitRoomConfig<TTrack = unknown> extends LiveKitVolumeConfig {
   /** A connected Room instance from livekit-client. */
   room: LKRoom
   /** The createAudioAnalyser function from livekit-client. */
@@ -326,12 +348,19 @@ export function createLiveKitAdapter<TTrack = unknown>(
     emitSignal({ ...signal, ...patch, state: patch.state ?? signal.state })
   }
 
+  function getOutputVolumeCalibration() {
+    const overrides =
+      typeof config.outputVolumeCalibration === 'function'
+        ? config.outputVolumeCalibration()
+        : config.outputVolumeCalibration
+    return { ...DEFAULT_LIVEKIT_OUTPUT_CALIBRATION, ...overrides }
+  }
+
   function normalizeVolume(raw: number): number {
-    const gated = raw < NOISE_FLOOR ? 0 : raw
-    const rate = gated > outputEmaVolume ? EMA_ATTACK : EMA_RELEASE
-    outputEmaVolume = outputEmaVolume + (gated - outputEmaVolume) * rate
-    const gained = Math.min(outputEmaVolume * OUTPUT_GAIN, 1.0)
-    return gained / (gained + SIGMOID_K)
+    const sample = calibrateOutputVolume(raw, outputEmaVolume, getOutputVolumeCalibration)
+    outputEmaVolume = sample.normalized
+    config.onOutputVolumeSample?.(sample)
+    return sample.normalized
   }
 
   function resetOutputVolume() {
@@ -359,7 +388,7 @@ export function createLiveKitAdapter<TTrack = unknown>(
     localMicrophoneTrack = track
 
     try {
-      inputAnalyserResult = createAudioAnalyser(track)
+      inputAnalyserResult = createAudioAnalyser(track, LIVEKIT_ANALYSER_OPTIONS)
     } catch (err) {
       console.warn('[orb-ui/livekit] local createAudioAnalyser failed:', err)
       return
@@ -391,7 +420,7 @@ export function createLiveKitAdapter<TTrack = unknown>(
     stopOutputVolumeTracking()
 
     try {
-      outputAnalyserResult = createAudioAnalyser(track)
+      outputAnalyserResult = createAudioAnalyser(track, LIVEKIT_ANALYSER_OPTIONS)
     } catch (err) {
       console.warn('[orb-ui/livekit] remote createAudioAnalyser failed:', err)
       return

--- a/src/adapters/livekit/index.ts
+++ b/src/adapters/livekit/index.ts
@@ -103,10 +103,10 @@ const LIVEKIT_ANALYSER_OPTIONS = {
 
 const DEFAULT_LIVEKIT_OUTPUT_CALIBRATION: OutputVolumeCalibration = {
   noiseFloor: 0.015,
-  gain: 1.5,
-  exponent: 1.1,
-  attack: 0.28,
-  release: 0.08,
+  gain: 4.6,
+  exponent: 1.15,
+  attack: 0.1,
+  release: 0.48,
 }
 
 function mapAgentState(lkState: string): OrbState {

--- a/src/adapters/pipecat/index.test.ts
+++ b/src/adapters/pipecat/index.test.ts
@@ -98,8 +98,8 @@ describe('createPipecatAdapter', () => {
       state: 'speaking',
       inputVolume: 0,
     })
-    expect(signals.at(-1)?.volume).toBeCloseTo(0.6)
-    expect(signals.at(-1)?.outputVolume).toBeCloseTo(0.6)
+    expect(signals.at(-1)?.volume).toBeCloseTo(0.5)
+    expect(signals.at(-1)?.outputVolume).toBeCloseTo(0.5)
 
     client.emit('botStoppedSpeaking')
     expect(signals.at(-1)).toMatchObject({ state: 'listening', outputVolume: 0 })
@@ -172,7 +172,7 @@ describe('createPipecatAdapter', () => {
     expect(signals).toHaveLength(count)
 
     client.emit('remoteAudioLevel', 0.8, { id: 'bot', local: false })
-    expect(signals.at(-1)?.outputVolume).toBeCloseTo(0.6)
+    expect(signals.at(-1)?.outputVolume).toBeCloseTo(0.5)
   })
 
   it('amplifies realistic low levels and smooths attack and release independently', () => {

--- a/src/adapters/pipecat/index.test.ts
+++ b/src/adapters/pipecat/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createPipecatAdapter } from './index'
 import type { OrbSignal } from '../types'
 
@@ -8,6 +8,10 @@ class FakePipecatClient {
   state = 'disconnected'
   connect = vi.fn(async () => undefined)
   disconnect = vi.fn(async () => undefined)
+  trackSet?: {
+    local?: { audio?: MediaStreamTrack }
+    bot?: { audio?: MediaStreamTrack }
+  }
   private listeners = new Map<string, Set<Listener>>()
 
   on(event: string, listener: Listener) {
@@ -27,7 +31,42 @@ class FakePipecatClient {
   listenerCount(event: string) {
     return this.listeners.get(event)?.size ?? 0
   }
+
+  tracks() {
+    return this.trackSet ?? {}
+  }
 }
+
+class FakeAudioContext {
+  state: AudioContextState = 'running'
+  private sample: number
+  source = {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }
+  analyser = {
+    fftSize: 2048,
+    smoothingTimeConstant: 0.8,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    getFloatTimeDomainData: (samples: Float32Array) => samples.fill(this.sample),
+  }
+  createMediaStreamSource = vi.fn(() => this.source)
+  createAnalyser = vi.fn(() => this.analyser)
+  resume = vi.fn(async () => undefined)
+  close = vi.fn(async () => {
+    this.state = 'closed'
+  })
+
+  constructor(sample: number) {
+    this.sample = sample
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
 
 describe('createPipecatAdapter', () => {
   it('normalizes RTVI lifecycle, speaking, and audio-level events', async () => {
@@ -71,6 +110,51 @@ describe('createPipecatAdapter', () => {
 
     unsubscribe()
     expect(client.listenerCount('botReady')).toBe(0)
+  })
+
+  it('meters local and bot media tracks when transport audio-level events are unavailable', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'MediaStream',
+      class MediaStream {
+        constructor() {}
+      },
+    )
+
+    const localTrack = { kind: 'audio' } as MediaStreamTrack
+    const botTrack = { kind: 'audio' } as MediaStreamTrack
+    const client = new FakePipecatClient()
+    client.trackSet = {
+      local: { audio: localTrack },
+      bot: { audio: botTrack },
+    }
+    const inputContext = new FakeAudioContext(0.08)
+    const outputContext = new FakeAudioContext(0.16)
+    const contexts = [inputContext, outputContext]
+    const onOutputVolumeSample = vi.fn()
+    const adapter = createPipecatAdapter(client, {
+      createAudioContext: () => contexts.shift() as unknown as AudioContext,
+      onOutputVolumeSample,
+    })
+    const signals: OrbSignal[] = []
+    const unsubscribe = adapter.subscribe((signal) => signals.push(signal))
+
+    client.emit('botReady')
+    vi.advanceTimersByTime(33)
+    expect(signals.at(-1)).toMatchObject({ state: 'listening', outputVolume: 0 })
+    expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
+
+    client.emit('botStartedSpeaking')
+    vi.advanceTimersByTime(33)
+    expect(signals.at(-1)).toMatchObject({ state: 'speaking', inputVolume: 0 })
+    expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
+    expect(onOutputVolumeSample).toHaveBeenCalledWith(
+      expect.objectContaining({ raw: expect.closeTo(0.16) }),
+    )
+
+    unsubscribe()
+    expect(inputContext.close).toHaveBeenCalledOnce()
+    expect(outputContext.close).toHaveBeenCalledOnce()
   })
 
   it('filters local and non-bot participant volume', () => {

--- a/src/adapters/pipecat/index.ts
+++ b/src/adapters/pipecat/index.ts
@@ -1,4 +1,12 @@
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
+import { calibrateOutputVolume, createMediaStreamTrackVolumeMeter } from '../audio-level'
+import type {
+  AudioContextSource,
+  MediaStreamTrackVolumeMeter,
+  OutputVolumeCalibration,
+  OutputVolumeCalibrationSource,
+  OutputVolumeSample,
+} from '../audio-level'
 
 type PipecatListener = (...args: unknown[]) => void
 
@@ -10,12 +18,18 @@ export interface PipecatClientLike {
   connect(...args: unknown[]): Promise<unknown>
   disconnect(): void | Promise<void>
   state?: string
+  tracks?(): PipecatTracksLike
 }
 
 export interface PipecatParticipantLike {
   id?: string
   name?: string
   local?: boolean
+}
+
+export interface PipecatTracksLike {
+  local?: { audio?: MediaStreamTrack }
+  bot?: { audio?: MediaStreamTrack }
 }
 
 export interface PipecatAdapterOptions {
@@ -35,6 +49,12 @@ export interface PipecatAdapterOptions {
   playRemoteAudio?: boolean
   /** Runtime override for custom audio element ownership. */
   createAudioElement?: () => HTMLAudioElement
+  /** Return undefined to disable browser-track volume metering. */
+  createAudioContext?: AudioContextSource
+  /** Optional live-tunable output shaping. A getter is read for every meter sample. */
+  outputVolumeCalibration?: OutputVolumeCalibrationSource
+  /** Receives raw, shaped, and smoothed output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: OutputVolumeSample) => void
 }
 
 export interface PipecatOrbAdapter extends OrbAdapter {
@@ -70,6 +90,19 @@ const AUDIO_LEVEL_GAIN = 4
 const AUDIO_LEVEL_EXPONENT = 0.8
 const AUDIO_LEVEL_ATTACK = 0.6
 const AUDIO_LEVEL_RELEASE = 0.2
+const DEFAULT_PIPECAT_OUTPUT_CALIBRATION: OutputVolumeCalibration = {
+  noiseFloor: AUDIO_LEVEL_NOISE_FLOOR,
+  gain: AUDIO_LEVEL_GAIN,
+  exponent: AUDIO_LEVEL_EXPONENT,
+  attack: AUDIO_LEVEL_ATTACK,
+  release: AUDIO_LEVEL_RELEASE,
+}
+
+function defaultCreateAudioContext() {
+  if (typeof window === 'undefined') return undefined
+  const AudioContextClass = window.AudioContext
+  return AudioContextClass ? new AudioContextClass() : undefined
+}
 
 function stateFromTransport(state: string): OrbState | undefined {
   switch (state) {
@@ -137,6 +170,18 @@ export function createPipecatAdapter(
   let listening = false
   let inputLevel = 0
   let outputLevel = 0
+  let inputMeterTrack: MediaStreamTrack | null = null
+  let outputMeterTrack: MediaStreamTrack | null = null
+  let inputMeter: MediaStreamTrackVolumeMeter | undefined
+  let outputMeter: MediaStreamTrackVolumeMeter | undefined
+
+  function getOutputVolumeCalibration() {
+    const overrides =
+      typeof options.outputVolumeCalibration === 'function'
+        ? options.outputVolumeCalibration()
+        : options.outputVolumeCalibration
+    return { ...DEFAULT_PIPECAT_OUTPUT_CALIBRATION, ...overrides }
+  }
 
   function emit(next: OrbSignal) {
     signal = next
@@ -172,9 +217,62 @@ export function createPipecatAdapter(
       }
     }
 
-    outputLevel = smoothAudioLevel(level, outputLevel)
-    const outputVolume = outputLevel
+    const sample = calibrateOutputVolume(
+      typeof level === 'number' ? level : 0,
+      outputLevel,
+      getOutputVolumeCalibration,
+    )
+    outputLevel = sample.normalized
+    options.onOutputVolumeSample?.(sample)
+    const outputVolume = sample.normalized
     emit({ ...signal, volume: outputVolume, inputVolume: 0, outputVolume })
+  }
+
+  function stopInputMeter() {
+    inputMeterTrack = null
+    void inputMeter?.stop()
+    inputMeter = undefined
+  }
+
+  function stopOutputMeter() {
+    outputMeterTrack = null
+    void outputMeter?.stop()
+    outputMeter = undefined
+  }
+
+  function stopTrackMeters() {
+    stopInputMeter()
+    stopOutputMeter()
+  }
+
+  function startInputMeter(track: MediaStreamTrack) {
+    if (inputMeterTrack === track && inputMeter) return
+    stopInputMeter()
+    inputMeterTrack = track
+    inputMeter = createMediaStreamTrackVolumeMeter(
+      track,
+      options.createAudioContext ?? defaultCreateAudioContext,
+      emitInputVolume,
+    )
+    if (!inputMeter) inputMeterTrack = null
+  }
+
+  function startOutputMeter(track: MediaStreamTrack) {
+    if (outputMeterTrack === track && outputMeter) return
+    stopOutputMeter()
+    outputMeterTrack = track
+    outputMeter = createMediaStreamTrackVolumeMeter(
+      track,
+      options.createAudioContext ?? defaultCreateAudioContext,
+      emitOutputVolume,
+    )
+    if (!outputMeter) outputMeterTrack = null
+  }
+
+  function syncTrackMeters() {
+    const tracks = client.tracks?.()
+    if (tracks?.local?.audio) startInputMeter(tracks.local.audio)
+    if (tracks?.bot?.audio) startOutputMeter(tracks.bot.audio)
   }
 
   function isBotParticipant(participant: unknown) {
@@ -211,6 +309,25 @@ export function createPipecatAdapter(
     remoteAudioElements.delete(track)
   }
 
+  function handleTrackStarted(track: unknown, participant?: unknown) {
+    if (!isMediaStreamTrack(track) || track.kind !== 'audio') return
+
+    const knownLocalTrack = client.tracks?.().local?.audio
+    const local =
+      (participant as PipecatParticipantLike | undefined)?.local === true ||
+      track === knownLocalTrack
+    if (local) startInputMeter(track)
+    else if (isBotParticipant(participant)) startOutputMeter(track)
+
+    playRemoteTrack(track, participant)
+  }
+
+  function handleTrackStopped(track: unknown) {
+    if (track === inputMeterTrack) stopInputMeter()
+    if (track === outputMeterTrack) stopOutputMeter()
+    stopRemoteTrack(track)
+  }
+
   function stopRemoteAudio() {
     remoteAudioElements.forEach((audio) => {
       audio.pause()
@@ -220,11 +337,21 @@ export function createPipecatAdapter(
     remoteAudioElements.clear()
   }
 
+  function handleDisconnected() {
+    stopTrackMeters()
+    emitState('idle')
+  }
+
+  function handleBotReady() {
+    emitState('listening')
+    syncTrackMeters()
+  }
+
   const eventHandlers: Array<[string, PipecatListener]> = [
     [PIPECAT_EVENTS.connected, () => emitState('connecting')],
-    [PIPECAT_EVENTS.botReady, () => emitState('listening')],
-    [PIPECAT_EVENTS.disconnected, () => emitState('idle')],
-    [PIPECAT_EVENTS.botDisconnected, () => emitState('idle')],
+    [PIPECAT_EVENTS.botReady, handleBotReady],
+    [PIPECAT_EVENTS.disconnected, handleDisconnected],
+    [PIPECAT_EVENTS.botDisconnected, handleDisconnected],
     [
       PIPECAT_EVENTS.transportStateChanged,
       (state) => {
@@ -244,10 +371,13 @@ export function createPipecatAdapter(
     [PIPECAT_EVENTS.botTtsStarted, () => emitState('thinking')],
     [PIPECAT_EVENTS.botStartedSpeaking, () => emitState('speaking')],
     [PIPECAT_EVENTS.botStoppedSpeaking, () => emitState('listening')],
-    [PIPECAT_EVENTS.localAudioLevel, emitInputVolume],
-    [PIPECAT_EVENTS.remoteAudioLevel, emitOutputVolume],
-    ['trackStarted', playRemoteTrack],
-    ['trackStopped', stopRemoteTrack],
+    [PIPECAT_EVENTS.localAudioLevel, (level) => !inputMeter && emitInputVolume(level)],
+    [
+      PIPECAT_EVENTS.remoteAudioLevel,
+      (level, participant) => !outputMeter && emitOutputVolume(level, participant),
+    ],
+    ['trackStarted', handleTrackStarted],
+    ['trackStopped', handleTrackStopped],
     [PIPECAT_EVENTS.error, (error) => emitState('error', error)],
     [PIPECAT_EVENTS.messageError, (error) => emitState('error', error)],
     [PIPECAT_EVENTS.deviceError, (error) => emitState('error', error)],
@@ -266,6 +396,7 @@ export function createPipecatAdapter(
       if (client.off) client.off(event, listener)
       else client.removeListener?.(event, listener)
     })
+    stopTrackMeters()
     stopRemoteAudio()
   }
 
@@ -295,6 +426,7 @@ export function createPipecatAdapter(
       try {
         await (options.disconnect ? options.disconnect() : client.disconnect())
       } finally {
+        stopTrackMeters()
         stopRemoteAudio()
         emitState('idle')
       }

--- a/src/adapters/pipecat/index.ts
+++ b/src/adapters/pipecat/index.ts
@@ -85,17 +85,17 @@ const PIPECAT_EVENTS = {
 // speech commonly occupies only the bottom few hundredths of that range. Shape
 // those values before they reach a theme so quiet speech still produces useful
 // motion, then smooth the 100 ms level updates without making speech feel laggy.
-const AUDIO_LEVEL_NOISE_FLOOR = 0.002
-const AUDIO_LEVEL_GAIN = 4
-const AUDIO_LEVEL_EXPONENT = 0.8
-const AUDIO_LEVEL_ATTACK = 0.6
-const AUDIO_LEVEL_RELEASE = 0.2
+const INPUT_AUDIO_LEVEL_NOISE_FLOOR = 0.002
+const INPUT_AUDIO_LEVEL_GAIN = 4
+const INPUT_AUDIO_LEVEL_EXPONENT = 0.8
+const INPUT_AUDIO_LEVEL_ATTACK = 0.6
+const INPUT_AUDIO_LEVEL_RELEASE = 0.2
 const DEFAULT_PIPECAT_OUTPUT_CALIBRATION: OutputVolumeCalibration = {
-  noiseFloor: AUDIO_LEVEL_NOISE_FLOOR,
-  gain: AUDIO_LEVEL_GAIN,
-  exponent: AUDIO_LEVEL_EXPONENT,
-  attack: AUDIO_LEVEL_ATTACK,
-  release: AUDIO_LEVEL_RELEASE,
+  noiseFloor: 0.002,
+  gain: 5.1,
+  exponent: 0.8,
+  attack: 0.5,
+  release: 0.22,
 }
 
 function defaultCreateAudioContext() {
@@ -126,17 +126,21 @@ function stateFromTransport(state: string): OrbState | undefined {
 }
 
 function shapeAudioLevel(level: unknown): number {
-  if (typeof level !== 'number' || !Number.isFinite(level) || level <= AUDIO_LEVEL_NOISE_FLOOR) {
+  if (
+    typeof level !== 'number' ||
+    !Number.isFinite(level) ||
+    level <= INPUT_AUDIO_LEVEL_NOISE_FLOOR
+  ) {
     return 0
   }
 
-  const gated = Math.min(1, Math.max(0, level - AUDIO_LEVEL_NOISE_FLOOR))
-  return Math.pow(Math.min(1, gated * AUDIO_LEVEL_GAIN), AUDIO_LEVEL_EXPONENT)
+  const gated = Math.min(1, Math.max(0, level - INPUT_AUDIO_LEVEL_NOISE_FLOOR))
+  return Math.pow(Math.min(1, gated * INPUT_AUDIO_LEVEL_GAIN), INPUT_AUDIO_LEVEL_EXPONENT)
 }
 
 function smoothAudioLevel(level: unknown, previous: number): number {
   const shaped = shapeAudioLevel(level)
-  const rate = shaped > previous ? AUDIO_LEVEL_ATTACK : AUDIO_LEVEL_RELEASE
+  const rate = shaped > previous ? INPUT_AUDIO_LEVEL_ATTACK : INPUT_AUDIO_LEVEL_RELEASE
   return previous + (shaped - previous) * rate
 }
 

--- a/tests/package-typecheck/package-consumer.tsx
+++ b/tests/package-typecheck/package-consumer.tsx
@@ -69,6 +69,7 @@ const advancedLiveKitAdapter = createAdvancedLiveKitAdapter(liveKitConfig)
 const liveKitBrowserConfig: LiveKitBrowserAdapterConfig = {
   tokenEndpoint: '/api/livekit-token',
   agentName: 'support-agent',
+  outputVolumeCalibration: { attack: 0.3 },
 }
 const liveKitAdapter = createLiveKitAdapter(liveKitBrowserConfig)
 
@@ -78,7 +79,9 @@ const pipecatClient: PipecatClientLike = {
   connect: async () => undefined,
   disconnect: async () => undefined,
 }
-const pipecatAdapter = createPipecatAdapter(pipecatClient)
+const pipecatAdapter = createPipecatAdapter(pipecatClient, {
+  outputVolumeCalibration: { release: 0.2 },
+})
 
 const openAIRealtimeAdapter = createOpenAIRealtimeAdapter({
   getClientSecret: async () => 'short-lived-client-secret',

--- a/tests/typecheck/provider-adapters.tsx
+++ b/tests/typecheck/provider-adapters.tsx
@@ -38,6 +38,8 @@ const tokenElevenLabsAdapter = createElevenLabsAdapter(Conversation, {
 const liveKitAdapter = createLiveKitAdapter({
   tokenEndpoint: '/api/livekit-token',
   agentName: 'support-agent',
+  outputVolumeCalibration: { release: 0.12 },
+  onOutputVolumeSample: ({ normalized }) => void normalized,
 })
 
 // @ts-expect-error LiveKit sandbox sessions must identify the agent to dispatch.
@@ -56,6 +58,8 @@ const pipecatClient = new PipecatClient({
 })
 const pipecatAdapter = createPipecatAdapter(pipecatClient, {
   connect: () => pipecatClient.connect({ webrtcUrl: 'https://agent.example.com/api/offer' }),
+  outputVolumeCalibration: () => ({ gain: 3.5 }),
+  onOutputVolumeSample: ({ raw }) => void raw,
 })
 
 const openAIRealtimeAdapter = createOpenAIRealtimeAdapter({


### PR DESCRIPTION
## Summary

- widen LiveKit's analyser decibel range and tune attack/release smoothing so normal speech keeps visible word-level dynamics
- meter Pipecat local and bot browser audio tracks when transport audio-level events are missing or sparse
- adopt preview-tested `cloud` output presets for LiveKit and Pipecat
- expose live-tunable output calibration and diagnostic samples for both adapters
- document future theme- and direction-aware calibration work
- add playground controls, adapter documentation, roadmap notes, tests, and a patch changeset

## Why

LiveKit's analyser defaults used a narrow decibel window that could make ordinary agent speech appear pinned near maximum volume. Pipecat transports vary in whether and how frequently they emit RTVI audio-level events, which left input and output volume inactive with some SmallWebRTC sessions.

Provider-wide normalization is a useful baseline, but perceived motion also varies by theme and by speaking direction. This PR records that limitation in the roadmap without expanding the patch into a new calibration architecture.

## Verification

- `pnpm check`
- 39 unit tests passed
- 3 Chrome end-to-end tests passed
- package, examples, source, and demo typechecks passed
- library and demo production builds passed
- LiveKit and Pipecat output presets tuned against real preview sessions using the `cloud` theme

## Preview QA

- [x] confirm LiveKit output has smooth word-level variation without staying at maximum
- [ ] confirm Pipecat input volume reacts while listening
- [x] confirm Pipecat output volume reacts while the agent speaks
- [x] tune provider output presets in the live playground

## Release

Patch changeset included.

## AI authorship

Implemented and verified with OpenAI Codex (GPT-5) from the task: calibrate the LiveKit and Pipecat adapters based on cross-provider Cloud theme testing.