### PR TITLE
fix: repair breadcrumb structured data

### DIFF
--- a/docs/fix-breadcrumb-structured-data.js
+++ b/docs/fix-breadcrumb-structured-data.js
@@ -1,0 +1,101 @@
+/* global MutationObserver, URL, document, window */
+
+;(() => {
+  const jsonLdSelector = 'script[type="application/ld+json"]'
+
+  const normalizeUrl = (value) => {
+    if (typeof value !== 'string') return null
+
+    try {
+      const url = new URL(value, window.location.origin)
+      const pathname = url.pathname.replace(/\/+$/, '') || '/'
+      return `${url.origin}${pathname}`
+    } catch {
+      return null
+    }
+  }
+
+  const getItemUrl = (item) => {
+    if (typeof item === 'string') return item
+    if (item && typeof item === 'object' && typeof item['@id'] === 'string') {
+      return item['@id']
+    }
+    return null
+  }
+
+  const isBreadcrumbList = (entry) => {
+    const type = entry?.['@type']
+    return type === 'BreadcrumbList' || (Array.isArray(type) && type.includes('BreadcrumbList'))
+  }
+
+  const repairBreadcrumbs = (script) => {
+    let structuredData
+
+    try {
+      structuredData = JSON.parse(script.textContent || '{}')
+    } catch {
+      return
+    }
+
+    const graph = structuredData?.['@graph']
+    if (!Array.isArray(graph)) return
+
+    const currentPage = normalizeUrl(window.location.href)
+    const docsRoot = normalizeUrl('/docs')
+    let changed = false
+
+    for (const entry of graph) {
+      if (!isBreadcrumbList(entry)) continue
+
+      const items = entry.itemListElement
+      if (!Array.isArray(items) || items.length < 2) continue
+
+      const firstItem = items[0]
+      const lastItem = items[items.length - 1]
+      const lastItemUrl = normalizeUrl(getItemUrl(lastItem?.item))
+
+      // Mintlify omits `item` from a non-final group crumb when the current page is the
+      // first page in that group. Google only permits the final crumb to omit `item`.
+      if (!firstItem?.item && lastItemUrl === currentPage && docsRoot) {
+        firstItem.item = docsRoot
+        delete lastItem.item
+        changed = true
+      }
+    }
+
+    if (changed) script.textContent = JSON.stringify(structuredData)
+  }
+
+  const repairNode = (node) => {
+    if (node.nodeType !== 1) return
+    if (node.matches(jsonLdSelector)) repairBreadcrumbs(node)
+
+    for (const script of node.querySelectorAll(jsonLdSelector)) {
+      repairBreadcrumbs(script)
+    }
+  }
+
+  const start = () => {
+    for (const script of document.querySelectorAll(jsonLdSelector)) {
+      repairBreadcrumbs(script)
+    }
+
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        if (record.target.nodeType === 1 && record.target.matches(jsonLdSelector)) {
+          repairBreadcrumbs(record.target)
+        }
+
+        for (const node of record.addedNodes) repairNode(node)
+      }
+    })
+
+    observer.observe(document.documentElement, { childList: true, subtree: true })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true })
+  } else {
+    start()
+  }
+})()


### PR DESCRIPTION
## Summary

- repair Mintlify-generated breadcrumb JSON-LD when a section's first page is also the current page
- give the non-final section breadcrumb a stable docs URL
- leave the current page as the final breadcrumb, where Google permits omitting `item`
- observe client-side navigation so the repair also applies after Mintlify route transitions

## Root cause

Mintlify emits this shape for section-root pages:

```json
[
  { "position": 1, "name": "Guides" },
  { "position": 2, "name": "Voice Agent UI Components for React", "item": "https://orb-ui.com/docs/guides/voice-agent-ui" }
]
```

Google requires `item` on every breadcrumb except the final one, so Search Console marks the item invalid. The same generator behavior is present on other section roots such as `/docs/adapters/overview`.

The rendered repair produces:

```json
[
  { "position": 1, "name": "Guides", "item": "https://orb-ui.com/docs" },
  { "position": 2, "name": "Voice Agent UI Components for React" }
]
```

## User and SEO impact

The affected pages remain indexable; this restores their eligibility for breadcrumb-rich search results and prevents the same validation error from surfacing on other section roots.

## Validation

- reproduced the exact affected URL and payload in Google Search Console
- inspected the live JSON-LD on `/docs/guides/voice-agent-ui` and `/docs/adapters/overview`
- focused payload simulation confirms the failing schema is repaired
- focused regression simulation confirms valid child-page breadcrumbs are unchanged
- `pnpm check` — 42 unit tests and 4 Chrome E2E tests passed, along with formatting, lint, typechecks, and builds

No changeset or roadmap update is needed because this only corrects docs-site metadata.

Authored with Codex using GPT-5.6 Sol from the Search Console report and live-site reproduction.