### PR TITLE
feat: add homepage syntax highlighting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,16 @@ This repo is intentionally AI-native. Follow `CONTRIBUTING.md` first, then these
 - Breaking API changes need a changeset, migration notes, and matching docs/examples updates.
 - Do not mark a change as breaking for internal-only refactors.
 
+## Git and GitHub Workflow
+
+- Use local Git for branch creation, staging, commits, and pushes.
+- When a connected GitHub App is available, prefer it for repository metadata and pull request creation after the branch has been pushed.
+- Do not treat `gh auth status` as a universal prerequisite. An expired or missing GitHub CLI token only blocks operations that actually require `gh`; it does not block local Git, an authenticated `git push`, or the connected GitHub App.
+- Use `gh` as a fallback when the GitHub App is unavailable or does not support the required operation. Request `gh auth login` only when that fallback is genuinely required.
+- Before opening a PR, confirm the intended diff, push the current branch, derive the target repository from `origin`, and derive the base branch from `origin/HEAD` or GitHub App repository metadata.
+- Open draft PRs by default unless the user explicitly asks for a ready-for-review PR.
+- If publishing fails, report the failing layer precisely: local Git state, remote push authentication, GitHub App access, or GitHub CLI authentication.
+
 ## Product Direction
 
 - Keep public product planning in `ROADMAP.md`.

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Orb } from 'orb-ui'
 import type { OrbSignal, OrbState, OrbTheme } from 'orb-ui'
+import { highlightTsx } from './syntax-highlight'
 
 // Constants
 const STATES: OrbState[] = ['idle', 'connecting', 'listening', 'thinking', 'speaking', 'error']
@@ -417,6 +418,8 @@ export default function App() {
   }, [mode, manualState, manualVolume, simulation])
 
   const activeCodeOption = CODE_OPTIONS.find((option) => option.id === codeTab) ?? CODE_OPTIONS[0]
+  const activeCode = codeForTab(codeTab)
+  const highlightedCode = useMemo(() => highlightTsx(activeCode), [activeCode])
 
   const handleCopy = useCallback((target: Exclude<CopyTarget, null>, value: string) => {
     void navigator.clipboard.writeText(value)
@@ -1088,6 +1091,52 @@ export default function App() {
           white-space: pre;
         }
 
+        .code-token--attribute {
+          color: #ffcb6b;
+        }
+
+        .code-token--comment {
+          color: #707a8c;
+          font-style: italic;
+        }
+
+        .code-token--function {
+          color: #82b1ff;
+        }
+
+        .code-token--keyword {
+          color: #c792ea;
+        }
+
+        .code-token--literal,
+        .code-token--number {
+          color: #f78c6c;
+        }
+
+        .code-token--operator {
+          color: #89ddff;
+        }
+
+        .code-token--property {
+          color: #addb67;
+        }
+
+        .code-token--punctuation {
+          color: #9ba8b8;
+        }
+
+        .code-token--string {
+          color: #c3e88d;
+        }
+
+        .code-token--tag {
+          color: #f07178;
+        }
+
+        .code-token--type {
+          color: #ffcb6b;
+        }
+
         .docs-directory {
           margin: 0 auto;
           max-width: 1080px;
@@ -1461,7 +1510,7 @@ export default function App() {
           }
 
           .integration-workspace {
-            grid-template-columns: 1fr;
+            grid-template-columns: minmax(0, 1fr);
           }
 
           .integration-sidebar {
@@ -1879,14 +1928,24 @@ export default function App() {
                 <button
                   type="button"
                   className="code-window__copy"
-                  onClick={() => handleCopy('code', codeForTab(codeTab))}
+                  onClick={() => handleCopy('code', activeCode)}
                   aria-label={`Copy ${activeCodeOption.label} example`}
                 >
                   {copiedTarget === 'code' ? 'Copied' : 'Copy code'}
                 </button>
               </div>
               <pre>
-                <code>{codeForTab(codeTab)}</code>
+                <code className="language-tsx">
+                  {highlightedCode.map((token, index) =>
+                    token.kind === 'plain' ? (
+                      token.value
+                    ) : (
+                      <span key={index} className={`code-token--${token.kind}`}>
+                        {token.value}
+                      </span>
+                    ),
+                  )}
+                </code>
               </pre>
             </div>
           </div>

--- a/demo/src/syntax-highlight.ts
+++ b/demo/src/syntax-highlight.ts
@@ -1,0 +1,261 @@
+export type SyntaxTokenKind =
+  | 'attribute'
+  | 'comment'
+  | 'function'
+  | 'keyword'
+  | 'literal'
+  | 'number'
+  | 'operator'
+  | 'plain'
+  | 'property'
+  | 'punctuation'
+  | 'string'
+  | 'tag'
+  | 'type'
+
+export interface SyntaxToken {
+  kind: SyntaxTokenKind
+  value: string
+}
+
+const KEYWORDS = new Set([
+  'as',
+  'async',
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'export',
+  'extends',
+  'finally',
+  'for',
+  'from',
+  'function',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'instanceof',
+  'interface',
+  'let',
+  'new',
+  'of',
+  'return',
+  'switch',
+  'throw',
+  'try',
+  'type',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+])
+
+const LITERALS = new Set(['false', 'null', 'true', 'undefined'])
+const OPERATOR_CHARACTERS = new Set([
+  '!',
+  '%',
+  '&',
+  '*',
+  '+',
+  '-',
+  '.',
+  '/',
+  ':',
+  '<',
+  '=',
+  '>',
+  '?',
+  '|',
+  '~',
+])
+const PUNCTUATION_CHARACTERS = new Set(['(', ')', '[', ']', '{', '}', ',', ';'])
+
+function isIdentifierStart(character: string | undefined) {
+  return character !== undefined && /[A-Za-z_$]/.test(character)
+}
+
+function isIdentifierPart(character: string | undefined, allowHyphen: boolean) {
+  return character !== undefined && (/[\w$]/.test(character) || (allowHyphen && character === '-'))
+}
+
+function nextNonWhitespace(code: string, start: number) {
+  let index = start
+  while (/\s/.test(code[index] ?? '')) index += 1
+  return code[index]
+}
+
+function previousNonWhitespace(code: string, start: number) {
+  let index = start
+  while (index >= 0 && /\s/.test(code[index] ?? '')) index -= 1
+  return code[index]
+}
+
+function pushToken(tokens: SyntaxToken[], kind: SyntaxTokenKind, value: string) {
+  if (!value) return
+
+  const previous = tokens[tokens.length - 1]
+  if (previous?.kind === kind) {
+    previous.value += value
+    return
+  }
+
+  tokens.push({ kind, value })
+}
+
+function readQuotedValue(code: string, start: number) {
+  const quote = code[start]
+  let index = start + 1
+
+  while (index < code.length) {
+    if (code[index] === '\\') {
+      index += 2
+      continue
+    }
+
+    index += 1
+    if (code[index - 1] === quote) break
+  }
+
+  return index
+}
+
+function classifyIdentifier(
+  code: string,
+  value: string,
+  start: number,
+  end: number,
+  insideJsxTag: boolean,
+): SyntaxTokenKind {
+  if (insideJsxTag && nextNonWhitespace(code, end) === '=') return 'attribute'
+  if (KEYWORDS.has(value)) return 'keyword'
+  if (LITERALS.has(value)) return 'literal'
+  if (nextNonWhitespace(code, end) === '(') return 'function'
+  if (previousNonWhitespace(code, start - 1) === '.') return 'property'
+  if (/^[A-Z]/.test(value)) return 'type'
+  return 'plain'
+}
+
+/**
+ * Tokenizes the small TypeScript/JSX examples shown on the homepage. The returned
+ * values always reconstruct the original source, so copy-to-clipboard can keep
+ * using the untouched code string.
+ */
+export function highlightTsx(code: string): SyntaxToken[] {
+  const tokens: SyntaxToken[] = []
+  let index = 0
+  let insideJsxTag = false
+  let jsxExpressionDepth = 0
+
+  while (index < code.length) {
+    const character = code[index]
+    const nextCharacter = code[index + 1]
+
+    if (/\s/.test(character)) {
+      const start = index
+      while (index < code.length && /\s/.test(code[index])) index += 1
+      pushToken(tokens, 'plain', code.slice(start, index))
+      continue
+    }
+
+    if (character === '/' && nextCharacter === '/') {
+      const start = index
+      index = code.indexOf('\n', index)
+      if (index === -1) index = code.length
+      pushToken(tokens, 'comment', code.slice(start, index))
+      continue
+    }
+
+    if (character === '/' && nextCharacter === '*') {
+      const start = index
+      const closingIndex = code.indexOf('*/', index + 2)
+      index = closingIndex === -1 ? code.length : closingIndex + 2
+      pushToken(tokens, 'comment', code.slice(start, index))
+      continue
+    }
+
+    if (character === '"' || character === "'" || character === '`') {
+      const end = readQuotedValue(code, index)
+      pushToken(tokens, 'string', code.slice(index, end))
+      index = end
+      continue
+    }
+
+    const jsxTagMatch = code.slice(index).match(/^<\/?([A-Za-z_$][\w$.-]*)/)
+    if (!insideJsxTag && jsxExpressionDepth === 0 && jsxTagMatch) {
+      const prefixLength = jsxTagMatch[0].startsWith('</') ? 2 : 1
+      pushToken(tokens, 'punctuation', code.slice(index, index + prefixLength))
+      pushToken(tokens, 'tag', jsxTagMatch[1])
+      index += jsxTagMatch[0].length
+      insideJsxTag = true
+      continue
+    }
+
+    if (insideJsxTag && (code.startsWith('/>', index) || character === '>')) {
+      const value = code.startsWith('/>', index) ? '/>' : '>'
+      pushToken(tokens, 'punctuation', value)
+      index += value.length
+      insideJsxTag = false
+      continue
+    }
+
+    if (insideJsxTag && character === '{') {
+      pushToken(tokens, 'punctuation', character)
+      index += 1
+      insideJsxTag = false
+      jsxExpressionDepth = 1
+      continue
+    }
+
+    if (jsxExpressionDepth > 0 && (character === '{' || character === '}')) {
+      jsxExpressionDepth += character === '{' ? 1 : -1
+      pushToken(tokens, 'punctuation', character)
+      index += 1
+      if (jsxExpressionDepth === 0) insideJsxTag = true
+      continue
+    }
+
+    if (/\d/.test(character)) {
+      const start = index
+      while (index < code.length && /[\d._]/.test(code[index])) index += 1
+      pushToken(tokens, 'number', code.slice(start, index))
+      continue
+    }
+
+    if (isIdentifierStart(character)) {
+      const start = index
+      index += 1
+      while (isIdentifierPart(code[index], insideJsxTag)) index += 1
+      const value = code.slice(start, index)
+      pushToken(tokens, classifyIdentifier(code, value, start, index, insideJsxTag), value)
+      continue
+    }
+
+    if (OPERATOR_CHARACTERS.has(character)) {
+      const start = index
+      while (index < code.length && OPERATOR_CHARACTERS.has(code[index])) index += 1
+      pushToken(tokens, 'operator', code.slice(start, index))
+      continue
+    }
+
+    if (PUNCTUATION_CHARACTERS.has(character)) {
+      pushToken(tokens, 'punctuation', character)
+      index += 1
+      continue
+    }
+
+    pushToken(tokens, 'plain', character)
+    index += 1
+  }
+
+  return tokens
+}


### PR DESCRIPTION
## Summary

- add a dependency-free TypeScript/JSX tokenizer for the homepage examples
- render semantic colors for keywords, strings, types, calls, JSX tags and attributes, operators, literals, and comments
- preserve the original source string for copy-to-clipboard behavior
- constrain the quick-start grid at narrow breakpoints so long code scrolls inside the panel
- document the Codex Git/GitHub workflow in `AGENTS.md`, including that an expired `gh` token does not block authenticated Git pushes or the connected GitHub App

## Why

The homepage quick-start examples were rendered as a single neutral color, which made them harder to scan. This adds syntax highlighting without increasing the demo's dependency or bundle footprint.

Agents in this repository have also repeatedly treated GitHub CLI authentication as a prerequisite for all PR publishing. The new guidance distinguishes local Git, remote push authentication, GitHub App access, and `gh` authentication so agents use the working layer and report failures precisely.

## Verification

- `pnpm exec prettier demo/src/App.tsx demo/src/syntax-highlight.ts AGENTS.md --check`
- `pnpm lint`
- `pnpm --filter orb-ui-demo typecheck`
- `pnpm --filter orb-ui-demo build`
- desktop and 390px browser QA, including provider switching, semantic token rendering, mobile overflow behavior, and browser error checks

## Project notes

- No changeset: this only affects the demo website and repository contributor guidance; it does not change the published package API.
- No roadmap update: these are focused presentation and contributor-workflow improvements rather than progress on a roadmap item.

## Authorship

Implemented with OpenAI Codex from the prompts “can we add syntax highlighting to this section of the home page?” and “update the AGENTS.md with this git workflow.”