### PR TITLE
feat!: standardize directional volume calibration

### DIFF
--- a/.changeset/bright-orbs-calibrate.md
+++ b/.changeset/bright-orbs-calibrate.md
@@ -5,7 +5,8 @@
 Standardize every built-in provider adapter on separate input and output calibration profiles that
 map raw levels to a stable 0–1 speech envelope. Add semantic amplitude anchors, elapsed-time
 rise/fall processing, diagnostic samples, shipped provider defaults, and a guided playground
-calibration runner.
+calibration runner. Directional envelopes remain continuous across active-state transitions so
+provider mode events cannot force the animation through an artificial zero.
 
 This intentionally removes the ambiguous `volume` prop and `OrbSignal.volume`. Migrate controlled
 or custom integrations to `signal.inputVolume` while listening and `signal.outputVolume` while

--- a/.changeset/bright-orbs-calibrate.md
+++ b/.changeset/bright-orbs-calibrate.md
@@ -1,0 +1,12 @@
+---
+'orb-ui': minor
+---
+
+Standardize every built-in provider adapter on separate input and output calibration profiles that
+map raw levels to a stable 0–1 speech envelope. Add semantic amplitude anchors, elapsed-time
+rise/fall processing, diagnostic samples, shipped provider defaults, and a guided playground
+calibration runner.
+
+This intentionally removes the ambiguous `volume` prop and `OrbSignal.volume`. Migrate controlled
+or custom integrations to `signal.inputVolume` while listening and `signal.outputVolume` while
+speaking.

--- a/.changeset/bright-orbs-calibrate.md
+++ b/.changeset/bright-orbs-calibrate.md
@@ -8,6 +8,14 @@ rise/fall processing, diagnostic samples, shipped provider defaults, and a guide
 calibration runner. Directional envelopes remain continuous across active-state transitions so
 provider mode events cannot force the animation through an artificial zero.
 
+Retune ElevenLabs input/output and LiveKit output anchors from live SDK measurements so ordinary
+speech stays closer to the middle of the range. Preserve LiveKit input and Pipecat profiles, which
+already produced suitable levels in the same microphone test. Document repeatable audio QA and
+the distinction between frequency-based SDK meters and waveform RMS.
+
+Fix Pipecat generation events overriding the speaking animation while earlier audio is still
+playing. Playback retains priority until the bot stops or the user interrupts it.
+
 This intentionally removes the ambiguous `volume` prop and `OrbSignal.volume`. Migrate controlled
 or custom integrations to `signal.inputVolume` while listening and `signal.outputVolume` while
 speaking.

--- a/.changeset/bright-orbs-calibrate.md
+++ b/.changeset/bright-orbs-calibrate.md
@@ -8,13 +8,16 @@ rise/fall processing, diagnostic samples, shipped provider defaults, and a guide
 calibration runner. Directional envelopes remain continuous across active-state transitions so
 provider mode events cannot force the animation through an artificial zero.
 
-Retune ElevenLabs input/output and LiveKit output anchors from live SDK measurements so ordinary
+Retune ElevenLabs input/output, LiveKit output, and Gemini output anchors from live SDK measurements so ordinary
 speech stays closer to the middle of the range. Preserve LiveKit input and Pipecat profiles, which
 already produced suitable levels in the same microphone test. Document repeatable audio QA and
 the distinction between frequency-based SDK meters and waveform RMS.
 
 Fix Pipecat generation events overriding the speaking animation while earlier audio is still
 playing. Playback retains priority until the bot stops or the user interrupts it.
+
+Keep Gemini listening when the user interrupts and buffered output chunks arrive before the
+server stops playback. This prevents rapid listening/speaking animation switches during overlap.
 
 This intentionally removes the ambiguous `volume` prop and `OrbSignal.volume`. Migrate controlled
 or custom integrations to `signal.inputVolume` while listening and `signal.outputVolume` while

--- a/.changeset/openai-playback-priority.md
+++ b/.changeset/openai-playback-priority.md
@@ -1,0 +1,9 @@
+---
+'orb-ui': patch
+---
+
+Keep OpenAI Realtime playback events authoritative over volume-based state inference. Avoid a
+listening flash before the first playback packet and a false return to speaking as the output
+envelope fades after playback stops. Preserve listening during user interruption and retain
+meter-based fallback for integrations without playback events. Retune output amplitude anchors
+from live measurements so ordinary assistant speech reaches the shared midrange response.

--- a/.changeset/vapi-directional-meter.md
+++ b/.changeset/vapi-directional-meter.md
@@ -1,0 +1,11 @@
+---
+'orb-ui': minor
+---
+
+Measure Vapi microphone input from the existing SDK-owned audio track so listening responds to
+speech. Follow microphone replacement and mute, and clean up the meter without stopping provider
+tracks. Add input calibration and diagnostic callbacks while retaining compatibility with clients
+that only expose Vapi events. Retune the output profile for continuous SDK levels so ordinary
+assistant speech is no longer understated.
+
+Update the demo and SDK compatibility checks to Vapi 2.7.0, replacing its deprecated Daily runtime.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,16 @@ function App() {
   const [state, setState] = useState('idle')
   const [volume, setVolume] = useState(0)
 
-  return <Orb state={state} volume={volume} theme="circle" />
+  return (
+    <Orb
+      signal={{
+        state,
+        inputVolume: state === 'listening' ? volume : 0,
+        outputVolume: state === 'speaking' ? volume : 0,
+      }}
+      theme="circle"
+    />
+  )
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ export function VoiceOrb() {
 }
 ```
 
+Vapi uses its existing microphone track for listening motion and its assistant audio events for
+speaking motion. The adapter keeps microphone and output calibration separate.
+
 ## Install
 
 Install the component package:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,8 @@ Completed direction:
 - Replace provider-specific gain, curve, attack, and release constants with named amplitude anchors
   and elapsed-time envelope semantics
 - Ship directional defaults for every available provider signal
+- Keep available input and output envelopes warm across active conversation states so provider
+  mode events never inject an artificial zero
 - Add raw, mapped, and normalized diagnostics to all adapter volume callbacks
 - Generate profiles from guided silence, quiet, normal, and energetic captures in the provider
   playground instead of relying on manual sliders

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,24 @@ Target direction:
 - Remove callback-object adapter compatibility in 0.5.0 — complete
 - Remove surprising global audio behavior from `Orb`
 
+### Directional signal calibration — complete
+
+Every built-in adapter now emits a stable normalized speech envelope with the same semantic
+distribution: silence at `0`, ordinary speech around `0.5`, and strong uncommon peaks near `1`.
+Input and output use separate provider profiles because microphone and playback measurements have
+different raw distributions.
+
+Completed direction:
+
+- Replace provider-specific gain, curve, attack, and release constants with named amplitude anchors
+  and elapsed-time envelope semantics
+- Ship directional defaults for every available provider signal
+- Add raw, mapped, and normalized diagnostics to all adapter volume callbacks
+- Generate profiles from guided silence, quiet, normal, and energetic captures in the provider
+  playground instead of relying on manual sliders
+- Remove the ambiguous `volume` prop and `OrbSignal.volume` in favor of `inputVolume` and
+  `outputVolume`
+
 ### LiveKit adapter — complete
 
 First-class LiveKit Agents support includes signal-native state, local microphone and remote agent
@@ -82,17 +100,17 @@ controls:
 - Clear provider and controlled-mode paths
 - An editorial documentation directory for deeper implementation guidance
 
-### Theme- and direction-aware calibration — future
+### Theme response and customization — next
 
-Provider adapters currently normalize audio into a portable `OrbSignal`, but one provider-wide
-curve cannot guarantee the same perceived motion across themes. Theme geometry and animation range
-change how a normalized level feels, while human input and agent output can also need different
-response profiles.
+Provider adapters now normalize both directions into a portable `OrbSignal`. The next layer is a
+theme configuration API that lets applications choose an intentional preset or override a theme's
+appearance, geometry, and motion without changing provider measurement semantics.
 
-Future calibration work should explore:
+Next steps:
 
-- Independent input and output calibration profiles
-- Theme-level response mapping or presets layered on top of provider normalization
+- Add `balanced`, `calm`, and `expressive` presets while keeping today's behavior as `balanced`
+- Add theme-specific appearance, geometry, and motion overrides with semantic parameter names
+- Keep visual response timing and easing separate from provider rise/fall normalization
 - A playground matrix for comparing each provider, theme, and speaking direction
 - Keeping provider-specific measurement details out of theme implementations
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,9 +18,9 @@ Target direction:
 - Remove callback-object adapter compatibility in 0.5.0 — complete
 - Remove surprising global audio behavior from `Orb`
 
-### Directional signal calibration — complete
+### Directional signal calibration — release QA
 
-Every built-in adapter now emits a stable normalized speech envelope with the same semantic
+Every built-in adapter now targets a stable normalized speech envelope with the same semantic
 distribution: silence at `0`, ordinary speech around `0.5`, and strong uncommon peaks near `1`.
 Input and output use separate provider profiles because microphone and playback measurements have
 different raw distributions.
@@ -30,6 +30,9 @@ Completed direction:
 - Replace provider-specific gain, curve, attack, and release constants with named amplitude anchors
   and elapsed-time envelope semantics
 - Ship directional defaults for every available provider signal
+- Validate ElevenLabs, LiveKit, and Pipecat with live input/output recordings and controlled speech
+  through browser microphone processing; retune the profiles that overstate ordinary speech
+- Keep Pipecat playback reactive when overlapping LLM/TTS generation events arrive during speech
 - Keep available input and output envelopes warm across active conversation states so provider
   mode events never inject an artificial zero
 - Add raw, mapped, and normalized diagnostics to all adapter volume callbacks
@@ -37,6 +40,9 @@ Completed direction:
   playground instead of relying on manual sliders
 - Remove the ambiguous `volume` prop and `OrbSignal.volume` in favor of `inputVolume` and
   `outputVolume`
+
+Before release: finish live provider validation for Vapi, OpenAI Realtime, and Gemini Live, then
+review recorded traces across the built-in themes.
 
 ### LiveKit adapter — complete
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,8 +30,10 @@ Completed direction:
 - Replace provider-specific gain, curve, attack, and release constants with named amplitude anchors
   and elapsed-time envelope semantics
 - Ship directional defaults for every available provider signal
-- Validate ElevenLabs, LiveKit, Pipecat, and Gemini with live input/output recordings and controlled speech
+- Validate Vapi, ElevenLabs, LiveKit, Pipecat, and Gemini with live input/output recordings and controlled speech
   through browser microphone processing; retune the profiles that overstate ordinary speech
+- Meter Vapi microphone input from its SDK-owned track and tune continuous assistant output levels
+  against live recordings
 - Keep Pipecat playback reactive when overlapping LLM/TTS generation events arrive during speech
 - Keep Gemini listening during user interruption when buffered output chunks are still arriving
 - Keep available input and output envelopes warm across active conversation states so provider
@@ -42,7 +44,7 @@ Completed direction:
 - Remove the ambiguous `volume` prop and `OrbSignal.volume` in favor of `inputVolume` and
   `outputVolume`
 
-Before release: finish live provider validation for Vapi and OpenAI Realtime, then
+Before release: finish live provider validation for OpenAI Realtime, then
 review recorded traces across the built-in themes.
 
 ### LiveKit adapter — complete

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,12 +30,14 @@ Completed direction:
 - Replace provider-specific gain, curve, attack, and release constants with named amplitude anchors
   and elapsed-time envelope semantics
 - Ship directional defaults for every available provider signal
-- Validate Vapi, ElevenLabs, LiveKit, Pipecat, and Gemini with live input/output recordings and controlled speech
+- Validate Vapi, ElevenLabs, LiveKit, Pipecat, OpenAI Realtime, and Gemini with live input/output recordings and controlled speech
   through browser microphone processing; retune the profiles that overstate ordinary speech
 - Meter Vapi microphone input from its SDK-owned track and tune continuous assistant output levels
   against live recordings
 - Keep Pipecat playback reactive when overlapping LLM/TTS generation events arrive during speech
 - Keep Gemini listening during user interruption when buffered output chunks are still arriving
+- Use OpenAI WebRTC playback boundaries to prevent state flicker before audio arrives and after
+  playback ends; calibrate assistant output against independent live speech measurements
 - Keep available input and output envelopes warm across active conversation states so provider
   mode events never inject an artificial zero
 - Add raw, mapped, and normalized diagnostics to all adapter volume callbacks
@@ -44,8 +46,10 @@ Completed direction:
 - Remove the ambiguous `volume` prop and `OrbSignal.volume` in favor of `inputVolume` and
   `outputVolume`
 
-Before release: finish live provider validation for OpenAI Realtime, then
-review recorded traces across the built-in themes.
+Live provider validation and recorded trace review now cover all six providers across the four
+built-in themes. Before release: finish the visual review and merge the calibration/customization
+stack. Physical microphone and room-acoustic coverage remains outside the controlled digital
+microphone checks.
 
 ### LiveKit adapter — complete
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,9 +30,10 @@ Completed direction:
 - Replace provider-specific gain, curve, attack, and release constants with named amplitude anchors
   and elapsed-time envelope semantics
 - Ship directional defaults for every available provider signal
-- Validate ElevenLabs, LiveKit, and Pipecat with live input/output recordings and controlled speech
+- Validate ElevenLabs, LiveKit, Pipecat, and Gemini with live input/output recordings and controlled speech
   through browser microphone processing; retune the profiles that overstate ordinary speech
 - Keep Pipecat playback reactive when overlapping LLM/TTS generation events arrive during speech
+- Keep Gemini listening during user interruption when buffered output chunks are still arriving
 - Keep available input and output envelopes warm across active conversation states so provider
   mode events never inject an artificial zero
 - Add raw, mapped, and normalized diagnostics to all adapter volume callbacks
@@ -41,7 +42,7 @@ Completed direction:
 - Remove the ambiguous `volume` prop and `OrbSignal.volume` in favor of `inputVolume` and
   `outputVolume`
 
-Before release: finish live provider validation for Vapi, OpenAI Realtime, and Gemini Live, then
+Before release: finish live provider validation for Vapi and OpenAI Realtime, then
 review recorded traces across the built-in themes.
 
 ### LiveKit adapter — complete

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,7 @@
     "@pipecat-ai/client-js": "1.12.0",
     "@pipecat-ai/daily-transport": "1.6.7",
     "@pipecat-ai/small-webrtc-transport": "1.10.5",
-    "@vapi-ai/web": "2.5.2",
+    "@vapi-ai/web": "2.7.0",
     "livekit-client": "2.20.0",
     "orb-ui": "workspace:*"
   },

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -196,7 +196,7 @@ function getSimulationFrame(startedAt: number, now: number) {
 function signalFromStateVolume(state: OrbState, volume: number): OrbSignal {
   if (state === 'listening') return { state, inputVolume: volume }
   if (state === 'speaking') return { state, outputVolume: volume }
-  return { state, volume }
+  return { state }
 }
 
 function useConversationSimulation(startedAt: number) {

--- a/demo/src/provider-playground.css
+++ b/demo/src/provider-playground.css
@@ -208,13 +208,45 @@ input {
   margin: 10px 0 0;
 }
 
-.provider-calibration-sliders {
-  padding: 4px 0;
+.provider-calibration-phases {
+  display: grid;
+  gap: 8px;
 }
 
-.provider-calibration-sliders .provider-slider-row {
-  grid-template-columns: 76px minmax(0, 1fr) 42px;
-  font-size: 12px;
+.provider-calibration-phase {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 12px;
+  border: 1px solid #303030;
+  border-radius: 6px;
+  background: #151515;
+  color: #bdbdbd;
+  cursor: pointer;
+  padding: 10px 12px;
+  text-align: left;
+}
+
+.provider-calibration-phase:hover {
+  border-color: #5b5b5b;
+}
+
+.provider-calibration-phase.is-recording {
+  border-color: #c8ff9f;
+  box-shadow: 0 0 0 1px #c8ff9f inset;
+}
+
+.provider-calibration-phase strong {
+  color: #d7f7bf;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.provider-calibration-phase small {
+  grid-column: 1 / -1;
+  color: #777;
+  font-size: 11px;
+  line-height: 1.4;
 }
 
 .provider-preset-label {

--- a/demo/src/provider-playground.tsx
+++ b/demo/src/provider-playground.tsx
@@ -10,19 +10,26 @@ import {
   createOpenAIRealtimeAdapter,
   createPipecatAdapter,
   createVapiAdapter,
+  fitVolumeCalibration,
+  PROVIDER_VOLUME_CALIBRATIONS,
 } from 'orb-ui/adapters'
 import type {
+  DirectionalVolumeCalibration,
   GeminiLiveSession,
-  OutputVolumeCalibration,
-  OutputVolumeSample,
+  VolumeCalibration,
+  VolumeCalibrationCapture,
+  VolumeCalibrationFit,
+  VolumeSample,
 } from 'orb-ui/adapters'
 import './provider-playground.css'
 
 type ProviderId = 'manual' | 'vapi' | 'elevenlabs' | 'livekit' | 'pipecat' | 'openai' | 'gemini'
 type LiveKitConnectionMode = 'sandbox' | 'endpoint' | 'raw'
 type PipecatConnectionMode = 'cloud' | 'small-webrtc'
-type TunableProviderId = 'livekit' | 'pipecat' | 'openai' | 'gemini'
-type OutputCalibrationByProvider = Record<TunableProviderId, OutputVolumeCalibration>
+type CalibratableProviderId = Exclude<ProviderId, 'manual'>
+type VolumeDirection = 'input' | 'output'
+type CalibrationPhase = keyof VolumeCalibrationCapture
+type CalibrationByProvider = Record<CalibratableProviderId, DirectionalVolumeCalibration>
 
 interface ProviderConfig {
   vapiPublicKey: string
@@ -90,72 +97,75 @@ const DEFAULT_GEMINI_VOICE = 'Kore'
 const DEFAULT_INSTRUCTIONS =
   'You are a concise, friendly voice assistant helping test a realtime React UI.'
 
-const EMPTY_SIGNAL: OrbSignal = { state: 'idle', volume: 0, inputVolume: 0, outputVolume: 0 }
+const EMPTY_SIGNAL: OrbSignal = { state: 'idle', inputVolume: 0, outputVolume: 0 }
 const CONFIG_STORAGE_KEY = 'orb-ui:provider-playground-config'
-const CALIBRATION_STORAGE_KEY = 'orb-ui:provider-playground-output-calibration'
-const DEFAULT_OUTPUT_CALIBRATION: OutputCalibrationByProvider = {
-  livekit: {
-    noiseFloor: 0.015,
-    gain: 4.6,
-    exponent: 1.15,
-    attack: 0.1,
-    release: 0.48,
-  },
-  pipecat: {
-    noiseFloor: 0.002,
-    gain: 5.1,
-    exponent: 0.8,
-    attack: 0.5,
-    release: 0.22,
-  },
-  openai: {
-    noiseFloor: 0.003,
-    gain: 4,
-    exponent: 0.8,
-    attack: 0.55,
-    release: 0.1,
-  },
-  gemini: {
-    noiseFloor: 0.003,
-    gain: 4,
-    exponent: 0.8,
-    attack: 0.3,
-    release: 0.1,
-  },
-}
-
-const OUTPUT_CALIBRATION_CONTROLS: Array<{
-  key: keyof OutputVolumeCalibration
-  label: string
-  min: number
-  max: number
-  step: number
-  digits: number
-}> = [
-  { key: 'noiseFloor', label: 'Noise floor', min: 0, max: 0.05, step: 0.001, digits: 3 },
-  { key: 'gain', label: 'Gain', min: 1, max: 12, step: 0.1, digits: 1 },
-  { key: 'exponent', label: 'Curve', min: 0.3, max: 1.5, step: 0.05, digits: 2 },
-  { key: 'attack', label: 'Attack', min: 0.05, max: 1, step: 0.05, digits: 2 },
-  { key: 'release', label: 'Release', min: 0.02, max: 1, step: 0.02, digits: 2 },
+const CALIBRATION_STORAGE_KEY = 'orb-ui:provider-playground-volume-calibration-v2'
+const CALIBRATABLE_PROVIDERS: CalibratableProviderId[] = [
+  'vapi',
+  'elevenlabs',
+  'livekit',
+  'pipecat',
+  'openai',
+  'gemini',
 ]
-
-function isTunableProvider(provider: ProviderId): provider is TunableProviderId {
-  return (
-    provider === 'livekit' ||
-    provider === 'pipecat' ||
-    provider === 'openai' ||
-    provider === 'gemini'
-  )
+const CALIBRATION_PHASES: Array<{
+  id: CalibrationPhase
+  label: string
+  instruction: string
+}> = [
+  { id: 'silence', label: '1. Silence', instruction: 'Pause without speaking.' },
+  { id: 'quiet', label: '2. Quiet', instruction: 'Speak softly at a natural distance.' },
+  { id: 'normal', label: '3. Normal', instruction: 'Speak at your normal conversational level.' },
+  { id: 'energetic', label: '4. Energetic', instruction: 'Speak energetically without shouting.' },
+]
+const EMPTY_CAPTURE: VolumeCalibrationCapture = {
+  silence: [],
+  quiet: [],
+  normal: [],
+  energetic: [],
 }
 
-function copyOutputCalibration(
-  calibration: OutputCalibrationByProvider,
-): OutputCalibrationByProvider {
+function isCalibratableProvider(provider: ProviderId): provider is CalibratableProviderId {
+  return provider !== 'manual'
+}
+
+function supportsDirection(provider: CalibratableProviderId, direction: VolumeDirection) {
+  return direction === 'output' || provider !== 'vapi'
+}
+
+function copyCalibration(calibration: VolumeCalibration): VolumeCalibration {
   return {
-    livekit: { ...calibration.livekit },
-    pipecat: { ...calibration.pipecat },
-    openai: { ...calibration.openai },
-    gemini: { ...calibration.gemini },
+    amplitude: { ...calibration.amplitude },
+    envelope: { ...calibration.envelope },
+  }
+}
+
+function copyDirectionalCalibration(
+  calibration: DirectionalVolumeCalibration,
+): DirectionalVolumeCalibration {
+  return {
+    input: calibration.input ? copyCalibration(calibration.input) : undefined,
+    output: calibration.output ? copyCalibration(calibration.output) : undefined,
+  }
+}
+
+function copyProviderCalibrations(): CalibrationByProvider {
+  return {
+    vapi: copyDirectionalCalibration(PROVIDER_VOLUME_CALIBRATIONS.vapi),
+    elevenlabs: copyDirectionalCalibration(PROVIDER_VOLUME_CALIBRATIONS.elevenlabs),
+    livekit: copyDirectionalCalibration(PROVIDER_VOLUME_CALIBRATIONS.livekit),
+    pipecat: copyDirectionalCalibration(PROVIDER_VOLUME_CALIBRATIONS.pipecat),
+    openai: copyDirectionalCalibration(PROVIDER_VOLUME_CALIBRATIONS.openai),
+    gemini: copyDirectionalCalibration(PROVIDER_VOLUME_CALIBRATIONS.gemini),
+  }
+}
+
+function copyCapture(capture: VolumeCalibrationCapture): VolumeCalibrationCapture {
+  return {
+    silence: [...capture.silence],
+    quiet: [...capture.quiet],
+    normal: [...capture.normal],
+    energetic: [...capture.energetic],
   }
 }
 
@@ -219,8 +229,31 @@ function getStorage() {
   }
 }
 
-function readStoredOutputCalibration(): OutputCalibrationByProvider {
-  const defaults = copyOutputCalibration(DEFAULT_OUTPUT_CALIBRATION)
+function readCalibration(value: unknown): VolumeCalibration | undefined {
+  if (!isRecord(value) || !isRecord(value.amplitude) || !isRecord(value.envelope)) {
+    return undefined
+  }
+
+  const { silenceFloor, speechReference, speechPeak } = value.amplitude
+  const { riseTimeMs, fallTimeMs } = value.envelope
+  if (
+    typeof silenceFloor !== 'number' ||
+    typeof speechReference !== 'number' ||
+    typeof speechPeak !== 'number' ||
+    typeof riseTimeMs !== 'number' ||
+    typeof fallTimeMs !== 'number'
+  ) {
+    return undefined
+  }
+
+  return {
+    amplitude: { silenceFloor, speechReference, speechPeak },
+    envelope: { riseTimeMs, fallTimeMs },
+  }
+}
+
+function readStoredCalibration(): CalibrationByProvider {
+  const defaults = copyProviderCalibrations()
   const storage = getStorage()
   if (!storage) return defaults
 
@@ -228,14 +261,14 @@ function readStoredOutputCalibration(): OutputCalibrationByProvider {
     const parsed = JSON.parse(storage.getItem(CALIBRATION_STORAGE_KEY) ?? '{}')
     if (!isRecord(parsed)) return defaults
 
-    for (const provider of ['livekit', 'pipecat', 'openai', 'gemini'] as const) {
+    for (const provider of CALIBRATABLE_PROVIDERS) {
       const storedProvider = parsed[provider]
       if (!isRecord(storedProvider)) continue
 
-      for (const control of OUTPUT_CALIBRATION_CONTROLS) {
-        const value = storedProvider[control.key]
-        if (typeof value === 'number' && Number.isFinite(value)) {
-          defaults[provider][control.key] = value
+      for (const direction of ['input', 'output'] as const) {
+        const calibration = readCalibration(storedProvider[direction])
+        if (calibration && supportsDirection(provider, direction)) {
+          defaults[provider][direction] = calibration
         }
       }
     }
@@ -246,7 +279,7 @@ function readStoredOutputCalibration(): OutputCalibrationByProvider {
   }
 }
 
-function writeStoredOutputCalibration(calibration: OutputCalibrationByProvider) {
+function writeStoredCalibration(calibration: CalibrationByProvider) {
   const storage = getStorage()
   if (!storage) return
 
@@ -426,9 +459,9 @@ function formatVolume(value: number | undefined) {
 }
 
 function createManualSignal(state: OrbState, inputVolume: number, outputVolume: number): OrbSignal {
-  if (state === 'listening') return { state, inputVolume, volume: inputVolume }
-  if (state === 'speaking') return { state, outputVolume, volume: outputVolume }
-  return { state, volume: 0, inputVolume: 0, outputVolume: 0 }
+  if (state === 'listening') return { state, inputVolume }
+  if (state === 'speaking') return { state, outputVolume }
+  return { state, inputVolume: 0, outputVolume: 0 }
 }
 
 function getProviderReady(provider: ProviderId, config: ProviderConfig) {
@@ -523,7 +556,7 @@ function createLazyAdapter(factory: () => OrbAdapter | Promise<OrbAdapter>): Orb
         await adapter.start?.()
       } catch (error) {
         console.error('[orb-ui/demo] Provider start failed:', error)
-        emit({ state: 'error', volume: 0, inputVolume: 0, outputVolume: 0, error })
+        emit({ state: 'error', inputVolume: 0, outputVolume: 0, error })
       }
     },
 
@@ -536,9 +569,11 @@ function createLazyAdapter(factory: () => OrbAdapter | Promise<OrbAdapter>): Orb
 function createProviderAdapter(
   provider: ProviderId,
   config: ProviderConfig,
-  outputCalibration?: {
-    get: () => OutputVolumeCalibration
-    onSample: (sample: OutputVolumeSample) => void
+  volumeCalibration?: {
+    getInput: () => VolumeCalibration
+    getOutput: () => VolumeCalibration
+    onInputSample: (sample: VolumeSample) => void
+    onOutputSample: (sample: VolumeSample) => void
   },
 ): OrbAdapter | undefined {
   if (provider === 'vapi' && getProviderReady(provider, config)) {
@@ -546,6 +581,8 @@ function createProviderAdapter(
       const vapiModule = await import('@vapi-ai/web')
       return createVapiAdapter(new (getVapiConstructor(vapiModule.default))(config.vapiPublicKey), {
         assistantId: config.vapiAssistantId,
+        outputVolumeCalibration: volumeCalibration?.getOutput,
+        onOutputVolumeSample: volumeCalibration?.onOutputSample,
       })
     })
   }
@@ -555,6 +592,10 @@ function createProviderAdapter(
       const { Conversation } = await import('@elevenlabs/client')
       return createElevenLabsAdapter(Conversation, {
         agentId: config.elevenLabsAgentId,
+        inputVolumeCalibration: volumeCalibration?.getInput,
+        outputVolumeCalibration: volumeCalibration?.getOutput,
+        onInputVolumeSample: volumeCalibration?.onInputSample,
+        onOutputVolumeSample: volumeCalibration?.onOutputSample,
       })
     })
   }
@@ -575,8 +616,10 @@ function createProviderAdapter(
       })
 
       return createPipecatAdapter(client, {
-        outputVolumeCalibration: outputCalibration?.get,
-        onOutputVolumeSample: outputCalibration?.onSample,
+        inputVolumeCalibration: volumeCalibration?.getInput,
+        outputVolumeCalibration: volumeCalibration?.getOutput,
+        onInputVolumeSample: volumeCalibration?.onInputSample,
+        onOutputVolumeSample: volumeCalibration?.onOutputSample,
         connect:
           config.pipecatConnectionMode === 'cloud'
             ? () =>
@@ -595,8 +638,10 @@ function createProviderAdapter(
   if (provider === 'openai' && getProviderReady(provider, config)) {
     return createLazyAdapter(() =>
       createOpenAIRealtimeAdapter({
-        outputVolumeCalibration: outputCalibration?.get,
-        onOutputVolumeSample: outputCalibration?.onSample,
+        inputVolumeCalibration: volumeCalibration?.getInput,
+        outputVolumeCalibration: volumeCalibration?.getOutput,
+        onInputVolumeSample: volumeCalibration?.onInputSample,
+        onOutputVolumeSample: volumeCalibration?.onOutputSample,
         getClientSecret: () =>
           postProviderJson<{ value: string }>('/api/openai-realtime-token', {
             apiKey: config.openAIApiKey,
@@ -611,8 +656,10 @@ function createProviderAdapter(
   if (provider === 'gemini' && getProviderReady(provider, config)) {
     return createLazyAdapter(() =>
       createGeminiLiveAdapter({
-        outputVolumeCalibration: outputCalibration?.get,
-        onOutputVolumeSample: outputCalibration?.onSample,
+        inputVolumeCalibration: volumeCalibration?.getInput,
+        outputVolumeCalibration: volumeCalibration?.getOutput,
+        onInputVolumeSample: volumeCalibration?.onInputSample,
+        onOutputVolumeSample: volumeCalibration?.onOutputSample,
         connect: async (callbacks) => {
           const { GoogleGenAI } = await import('@google/genai')
           const token = await postProviderJson<{
@@ -649,8 +696,10 @@ function createProviderAdapter(
           sandboxId: config.liveKitSandboxId,
           agentName: config.liveKitAgentName,
           roomName: () => createLiveKitRoomName(config.liveKitRoomPrefix),
-          outputVolumeCalibration: outputCalibration?.get,
-          onOutputVolumeSample: outputCalibration?.onSample,
+          inputVolumeCalibration: volumeCalibration?.getInput,
+          outputVolumeCalibration: volumeCalibration?.getOutput,
+          onInputVolumeSample: volumeCalibration?.onInputSample,
+          onOutputVolumeSample: volumeCalibration?.onOutputSample,
         })
       }
 
@@ -661,8 +710,10 @@ function createProviderAdapter(
           tokenEndpoint: config.liveKitTokenEndpoint,
           agentName: config.liveKitAgentName,
           roomName: () => createLiveKitRoomName(config.liveKitRoomPrefix),
-          outputVolumeCalibration: outputCalibration?.get,
-          onOutputVolumeSample: outputCalibration?.onSample,
+          inputVolumeCalibration: volumeCalibration?.getInput,
+          outputVolumeCalibration: volumeCalibration?.getOutput,
+          onInputVolumeSample: volumeCalibration?.onInputSample,
+          onOutputVolumeSample: volumeCalibration?.onOutputSample,
         })
       }
 
@@ -672,8 +723,10 @@ function createProviderAdapter(
         participantToken: config.liveKitParticipantToken,
         createAudioAnalyser,
         RoomClass: Room,
-        outputVolumeCalibration: outputCalibration?.get,
-        onOutputVolumeSample: outputCalibration?.onSample,
+        inputVolumeCalibration: volumeCalibration?.getInput,
+        outputVolumeCalibration: volumeCalibration?.getOutput,
+        onInputVolumeSample: volumeCalibration?.onInputSample,
+        onOutputVolumeSample: volumeCalibration?.onOutputSample,
       })
     })
   }
@@ -701,57 +754,97 @@ function SignalRow({ label, value }: { label: string; value: string }) {
   )
 }
 
-function OutputCalibrationControls({
-  calibration,
-  onChange,
+function GuidedCalibrationControls({
+  provider,
+  direction,
+  onDirectionChange,
+  capture,
+  activePhase,
+  onTogglePhase,
+  onGenerate,
   onReset,
-  peakRaw,
+  calibration,
   sample,
+  fit,
 }: {
-  calibration: OutputVolumeCalibration
-  onChange: (key: keyof OutputVolumeCalibration, value: number) => void
+  provider: CalibratableProviderId
+  direction: VolumeDirection
+  onDirectionChange: (direction: VolumeDirection) => void
+  capture: VolumeCalibrationCapture
+  activePhase: CalibrationPhase | undefined
+  onTogglePhase: (phase: CalibrationPhase) => void
+  onGenerate: () => void
   onReset: () => void
-  peakRaw: number
-  sample: OutputVolumeSample | undefined
+  calibration: VolumeCalibration
+  sample: VolumeSample | undefined
+  fit: VolumeCalibrationFit | undefined
 }) {
+  const readyToGenerate = CALIBRATION_PHASES.every(({ id }) => capture[id].length > 0)
+
   return (
     <section className="provider-panel provider-diagnostics">
       <div className="provider-calibration-heading">
-        <span className="provider-label">Live Output Calibration</span>
+        <span className="provider-label">Guided Volume Calibration</span>
         <button className="provider-button" onClick={onReset} type="button">
-          Reset suggested
+          Reset shipped
         </button>
       </div>
       <p className="provider-note">
-        These controls update the active session immediately. Lower attack/release values add more
-        smoothing; lower curve values lift quiet audio.
+        Start the provider session, capture all four speaking conditions, then generate a profile.
+        The active session uses the generated values immediately.
       </p>
-      <div className="provider-sliders provider-calibration-sliders">
-        {OUTPUT_CALIBRATION_CONTROLS.map((control) => (
-          <label className="provider-slider-row" key={control.key}>
-            <span>{control.label}</span>
-            <input
-              data-testid={`output-calibration-${control.key}`}
-              max={control.max}
-              min={control.min}
-              onChange={(event) => onChange(control.key, Number(event.currentTarget.value))}
-              step={control.step}
-              type="range"
-              value={calibration[control.key]}
-            />
-            <span>{calibration[control.key].toFixed(control.digits)}</span>
-          </label>
+      <div className="provider-control-group">
+        <span className="provider-label">Direction</span>
+        <div className="provider-segment">
+          {(['input', 'output'] as const).map((item) => (
+            <button
+              className={`provider-button ${direction === item ? 'is-selected' : ''}`}
+              disabled={!supportsDirection(provider, item)}
+              key={item}
+              onClick={() => onDirectionChange(item)}
+              type="button"
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="provider-calibration-phases">
+        {CALIBRATION_PHASES.map((phase) => (
+          <button
+            className={`provider-calibration-phase ${activePhase === phase.id ? 'is-recording' : ''}`}
+            key={phase.id}
+            onClick={() => onTogglePhase(phase.id)}
+            type="button"
+          >
+            <span>{phase.label}</span>
+            <strong>{capture[phase.id].length} samples</strong>
+            <small>{phase.instruction}</small>
+          </button>
         ))}
       </div>
+      <button
+        className="provider-button"
+        disabled={!readyToGenerate || activePhase !== undefined}
+        onClick={onGenerate}
+        type="button"
+      >
+        Generate {direction} profile
+      </button>
       <div className="provider-signal-list">
-        <SignalRow label="raw RMS" value={(sample?.raw ?? 0).toFixed(4)} />
-        <SignalRow label="peak raw" value={peakRaw.toFixed(4)} />
-        <SignalRow label="shaped" value={(sample?.shaped ?? 0).toFixed(3)} />
-        <SignalRow label="smoothed" value={(sample?.normalized ?? 0).toFixed(3)} />
+        <SignalRow label="raw" value={(sample?.raw ?? 0).toFixed(4)} />
+        <SignalRow label="mapped" value={(sample?.mapped ?? 0).toFixed(3)} />
+        <SignalRow label="normalized" value={(sample?.normalized ?? 0).toFixed(3)} />
+        {fit ? (
+          <SignalRow
+            label="mapped medians"
+            value={`${fit.metrics.quietMedian.toFixed(2)} / ${fit.metrics.normalMedian.toFixed(2)} / ${fit.metrics.energeticMedian.toFixed(2)}`}
+          />
+        ) : null}
       </div>
-      <span className="provider-label provider-preset-label">Preset to send back</span>
-      <pre className="provider-code" data-testid="output-calibration-preset">
-        {JSON.stringify(calibration)}
+      <span className="provider-label provider-preset-label">Generated provider profile</span>
+      <pre className="provider-code" data-testid="volume-calibration-profile">
+        {JSON.stringify(calibration, null, 2)}
       </pre>
     </section>
   )
@@ -1114,31 +1207,88 @@ function ProviderPlayground() {
   const [manualOutputVolume, setManualOutputVolume] = useState(0.65)
   const [latestSignal, setLatestSignal] = useState<OrbSignal>(EMPTY_SIGNAL)
   const [events, setEvents] = useState<EventEntry[]>([])
-  const [outputCalibration, setOutputCalibration] = useState<OutputCalibrationByProvider>(() =>
-    readStoredOutputCalibration(),
+  const [calibration, setCalibration] = useState<CalibrationByProvider>(() =>
+    readStoredCalibration(),
   )
-  const outputCalibrationRef = useRef(outputCalibration)
-  const [latestOutputSample, setLatestOutputSample] = useState<OutputVolumeSample>()
-  const [peakRawOutput, setPeakRawOutput] = useState(0)
+  const calibrationRef = useRef(calibration)
+  const [calibrationDirection, setCalibrationDirection] = useState<VolumeDirection>('input')
+  const [captures, setCaptures] = useState<Record<VolumeDirection, VolumeCalibrationCapture>>({
+    input: copyCapture(EMPTY_CAPTURE),
+    output: copyCapture(EMPTY_CAPTURE),
+  })
+  const [activeCapture, setActiveCapture] = useState<
+    { direction: VolumeDirection; phase: CalibrationPhase } | undefined
+  >()
+  const activeCaptureRef = useRef(activeCapture)
+  const [latestSamples, setLatestSamples] = useState<
+    Partial<Record<VolumeDirection, VolumeSample>>
+  >({})
+  const [lastFit, setLastFit] = useState<
+    | { provider: CalibratableProviderId; direction: VolumeDirection; fit: VolumeCalibrationFit }
+    | undefined
+  >()
 
   useEffect(() => {
     writeStoredConfig(config, provider, theme)
   }, [config, provider, theme])
 
   useEffect(() => {
-    outputCalibrationRef.current = outputCalibration
-    writeStoredOutputCalibration(outputCalibration)
-  }, [outputCalibration])
+    calibrationRef.current = calibration
+    writeStoredCalibration(calibration)
+  }, [calibration])
 
-  const getActiveOutputCalibration = useCallback(() => {
-    if (!isTunableProvider(provider)) return DEFAULT_OUTPUT_CALIBRATION.openai
-    return outputCalibrationRef.current[provider]
-  }, [provider])
+  useEffect(() => {
+    if (activeCapture?.phase !== 'silence') return
 
-  const recordOutputSample = useCallback((sample: OutputVolumeSample) => {
-    setLatestOutputSample(sample)
-    setPeakRawOutput((current) => Math.max(current, sample.raw))
+    // Some SDKs stop emitting meter callbacks when a direction is silent. A
+    // periodic zero records that absence as silence while real raw callbacks
+    // still determine the high-percentile floor.
+    const interval = window.setInterval(() => {
+      setCaptures((current) => ({
+        ...current,
+        [activeCapture.direction]: {
+          ...current[activeCapture.direction],
+          silence: [...current[activeCapture.direction].silence, 0].slice(-5000),
+        },
+      }))
+    }, 100)
+
+    return () => window.clearInterval(interval)
+  }, [activeCapture])
+
+  const getActiveCalibration = useCallback(
+    (direction: VolumeDirection) => {
+      if (!isCalibratableProvider(provider)) {
+        return copyCalibration(PROVIDER_VOLUME_CALIBRATIONS.openai[direction])
+      }
+      const current = calibrationRef.current[provider][direction]
+      return current ?? copyCalibration(PROVIDER_VOLUME_CALIBRATIONS.openai[direction])
+    },
+    [provider],
+  )
+
+  const recordVolumeSample = useCallback((direction: VolumeDirection, sample: VolumeSample) => {
+    setLatestSamples((current) => ({ ...current, [direction]: sample }))
+    const capture = activeCaptureRef.current
+    if (!capture || capture.direction !== direction) return
+
+    setCaptures((current) => ({
+      ...current,
+      [direction]: {
+        ...current[direction],
+        [capture.phase]: [...current[direction][capture.phase], sample.raw].slice(-5000),
+      },
+    }))
   }, [])
+
+  const recordInputSample = useCallback(
+    (sample: VolumeSample) => recordVolumeSample('input', sample),
+    [recordVolumeSample],
+  )
+  const recordOutputSample = useCallback(
+    (sample: VolumeSample) => recordVolumeSample('output', sample),
+    [recordVolumeSample],
+  )
 
   const activeConfig = useMemo(() => normalizeConfig(config), [config])
   const providerReady = getProviderReady(provider, activeConfig)
@@ -1147,11 +1297,16 @@ function ProviderPlayground() {
       createProviderAdapter(
         provider,
         activeConfig,
-        isTunableProvider(provider)
-          ? { get: getActiveOutputCalibration, onSample: recordOutputSample }
+        isCalibratableProvider(provider)
+          ? {
+              getInput: () => getActiveCalibration('input'),
+              getOutput: () => getActiveCalibration('output'),
+              onInputSample: recordInputSample,
+              onOutputSample: recordOutputSample,
+            }
           : undefined,
       ),
-    [activeConfig, getActiveOutputCalibration, provider, recordOutputSample],
+    [activeConfig, getActiveCalibration, provider, recordInputSample, recordOutputSample],
   )
 
   const updateConfig = useCallback(function updateConfig<TKey extends keyof ProviderConfig>(
@@ -1315,49 +1470,95 @@ function ProviderPlayground() {
   useEffect(() => {
     setLatestSignal(EMPTY_SIGNAL)
     setEvents([])
-    setLatestOutputSample(undefined)
-    setPeakRawOutput(0)
+    setCalibrationDirection(provider === 'vapi' ? 'output' : 'input')
+    setCaptures({
+      input: copyCapture(EMPTY_CAPTURE),
+      output: copyCapture(EMPTY_CAPTURE),
+    })
+    activeCaptureRef.current = undefined
+    setActiveCapture(undefined)
+    setLatestSamples({})
+    setLastFit(undefined)
   }, [provider])
 
-  const updateOutputCalibration = useCallback(
-    (key: keyof OutputVolumeCalibration, value: number) => {
-      if (!isTunableProvider(provider)) return
-      setOutputCalibration((current) => {
-        const next = {
+  const toggleCapturePhase = useCallback(
+    (phase: CalibrationPhase) => {
+      const next =
+        activeCapture?.direction === calibrationDirection && activeCapture.phase === phase
+          ? undefined
+          : { direction: calibrationDirection, phase }
+
+      if (next) {
+        setCaptures((current) => ({
           ...current,
-          [provider]: { ...current[provider], [key]: value },
-        }
-        outputCalibrationRef.current = next
-        return next
-      })
+          [calibrationDirection]: {
+            ...current[calibrationDirection],
+            [phase]: [],
+          },
+        }))
+      }
+      activeCaptureRef.current = next
+      setActiveCapture(next)
     },
-    [provider],
+    [activeCapture, calibrationDirection],
   )
 
-  const resetOutputCalibration = useCallback(() => {
-    if (!isTunableProvider(provider)) return
-    setOutputCalibration((current) => {
+  const generateCalibration = useCallback(() => {
+    if (!isCalibratableProvider(provider)) return
+    const fit = fitVolumeCalibration(captures[calibrationDirection])
+    setCalibration((current) => {
       const next = {
         ...current,
-        [provider]: { ...DEFAULT_OUTPUT_CALIBRATION[provider] },
+        [provider]: {
+          ...current[provider],
+          [calibrationDirection]: fit.calibration,
+        },
       }
-      outputCalibrationRef.current = next
+      calibrationRef.current = next
       return next
     })
-    setLatestOutputSample(undefined)
-    setPeakRawOutput(0)
-  }, [provider])
+    setLastFit({ provider, direction: calibrationDirection, fit })
+  }, [calibrationDirection, captures, provider])
+
+  const resetCalibration = useCallback(() => {
+    if (!isCalibratableProvider(provider)) return
+    const shipped = copyProviderCalibrations()[provider][calibrationDirection]
+    if (!shipped) return
+    setCalibration((current) => {
+      const next = {
+        ...current,
+        [provider]: {
+          ...current[provider],
+          [calibrationDirection]: copyCalibration(shipped),
+        },
+      }
+      calibrationRef.current = next
+      return next
+    })
+    setCaptures((current) => ({
+      ...current,
+      [calibrationDirection]: copyCapture(EMPTY_CAPTURE),
+    }))
+    activeCaptureRef.current = undefined
+    setActiveCapture(undefined)
+    setLatestSamples((current) => ({ ...current, [calibrationDirection]: undefined }))
+    setLastFit(undefined)
+  }, [calibrationDirection, provider])
+
+  const changeCalibrationDirection = useCallback((direction: VolumeDirection) => {
+    activeCaptureRef.current = undefined
+    setActiveCapture(undefined)
+    setCalibrationDirection(direction)
+  }, [])
 
   const displayedSignal = provider === 'manual' ? manualSignal : latestSignal
   const activeState = provider === 'manual' ? manualSignal.state : latestSignal.state
   const activeVolume =
-    provider === 'manual'
-      ? manualSignal.volume
-      : activeState === 'listening'
-        ? (latestSignal.inputVolume ?? latestSignal.volume)
-        : activeState === 'speaking'
-          ? (latestSignal.outputVolume ?? latestSignal.volume)
-          : latestSignal.volume
+    activeState === 'listening'
+      ? (displayedSignal.inputVolume ?? 0)
+      : activeState === 'speaking'
+        ? (displayedSignal.outputVolume ?? 0)
+        : 0
 
   const updateManualState = useCallback(
     (state: OrbState) => {
@@ -1608,13 +1809,27 @@ function ProviderPlayground() {
               </section>
             ) : null}
 
-            {isTunableProvider(provider) ? (
-              <OutputCalibrationControls
-                calibration={outputCalibration[provider]}
-                onChange={updateOutputCalibration}
-                onReset={resetOutputCalibration}
-                peakRaw={peakRawOutput}
-                sample={latestOutputSample}
+            {isCalibratableProvider(provider) ? (
+              <GuidedCalibrationControls
+                activePhase={
+                  activeCapture?.direction === calibrationDirection
+                    ? activeCapture.phase
+                    : undefined
+                }
+                calibration={getActiveCalibration(calibrationDirection)}
+                capture={captures[calibrationDirection]}
+                direction={calibrationDirection}
+                fit={
+                  lastFit?.provider === provider && lastFit.direction === calibrationDirection
+                    ? lastFit.fit
+                    : undefined
+                }
+                onDirectionChange={changeCalibrationDirection}
+                onGenerate={generateCalibration}
+                onReset={resetCalibration}
+                onTogglePhase={toggleCapturePhase}
+                provider={provider}
+                sample={latestSamples[calibrationDirection]}
               />
             ) : null}
 
@@ -1622,7 +1837,6 @@ function ProviderPlayground() {
               <span className="provider-label">Latest Signal</span>
               <div className="provider-signal-list">
                 <SignalRow label="state" value={displayedSignal.state} />
-                <SignalRow label="volume" value={formatVolume(displayedSignal.volume)} />
                 <SignalRow label="inputVolume" value={formatVolume(displayedSignal.inputVolume)} />
                 <SignalRow
                   label="outputVolume"

--- a/demo/src/provider-playground.tsx
+++ b/demo/src/provider-playground.tsx
@@ -130,7 +130,7 @@ function isCalibratableProvider(provider: ProviderId): provider is CalibratableP
 }
 
 function supportsDirection(provider: CalibratableProviderId, direction: VolumeDirection) {
-  return direction === 'output' || provider !== 'vapi'
+  return Boolean(PROVIDER_VOLUME_CALIBRATIONS[provider][direction])
 }
 
 function copyCalibration(calibration: VolumeCalibration): VolumeCalibration {
@@ -581,7 +581,9 @@ function createProviderAdapter(
       const vapiModule = await import('@vapi-ai/web')
       return createVapiAdapter(new (getVapiConstructor(vapiModule.default))(config.vapiPublicKey), {
         assistantId: config.vapiAssistantId,
+        inputVolumeCalibration: volumeCalibration?.getInput,
         outputVolumeCalibration: volumeCalibration?.getOutput,
+        onInputVolumeSample: volumeCalibration?.onInputSample,
         onOutputVolumeSample: volumeCalibration?.onOutputSample,
       })
     })
@@ -1470,7 +1472,7 @@ function ProviderPlayground() {
   useEffect(() => {
     setLatestSignal(EMPTY_SIGNAL)
     setEvents([])
-    setCalibrationDirection(provider === 'vapi' ? 'output' : 'input')
+    setCalibrationDirection('input')
     setCaptures({
       input: copyCapture(EMPTY_CAPTURE),
       output: copyCapture(EMPTY_CAPTURE),

--- a/docs/adapters/custom.mdx
+++ b/docs/adapters/custom.mdx
@@ -25,7 +25,6 @@ events on one side of that boundary and emit the same small contract to React:
 ```ts
 type OrbSignal = {
   state: 'idle' | 'connecting' | 'listening' | 'thinking' | 'speaking' | 'error'
-  volume?: number
   inputVolume?: number
   outputVolume?: number
   error?: unknown
@@ -157,6 +156,7 @@ The orb can only reflect lifecycle accuracy if the underlying runtime actually r
 
 - Provider events map to the six supported states in one place.
 - Input and output levels are separately normalized between `0` and `1`.
+- Normal speech occupies the middle of the range instead of clustering near zero or one.
 - Every subscription has a matching cleanup function.
 - Start and stop can be called again after an error.
 - Microphone permission and connection failures have visible recovery actions.

--- a/docs/adapters/elevenlabs.mdx
+++ b/docs/adapters/elevenlabs.mdx
@@ -64,7 +64,10 @@ The ElevenLabs adapter is responsible for normalizing provider events into orb-u
 - speaking
 - error
 
-ElevenLabs input levels are emitted as `inputVolume` while listening, and output levels are emitted as `outputVolume` while speaking.
+ElevenLabs input levels are emitted as `inputVolume` while listening, and output levels are emitted
+as `outputVolume` while speaking. Separate shipped profiles map both into the same stable 0–1 speech
+envelope. The adapter accepts directional calibration overrides and diagnostic callbacks for custom
+audio paths; see [volume calibration](/guides/volume-calibration).
 
 The ElevenLabs mode surface does not expose a separate thinking event through this adapter, so the
 normal transition is listening to speaking. If your application has an authoritative processing

--- a/docs/adapters/elevenlabs.mdx
+++ b/docs/adapters/elevenlabs.mdx
@@ -126,9 +126,10 @@ independent of provider-specific event names.
 browser can reach the agent. For private agents, mint a fresh credential and verify that its
 connection type matches the credential shape.
 
-**The orb moves for only one side.** Input volume is read while the normalized state is listening;
-output volume is read while it is speaking. Confirm that ElevenLabs mode-change callbacks are
-arriving and that the browser granted microphone access.
+**The orb moves for only one side.** Both directional envelopes stay current, but `Orb` renders
+input volume while the normalized state is listening and output volume while it is speaking.
+Confirm that ElevenLabs mode-change callbacks are arriving and that the browser granted microphone
+access.
 
 **A stopped session still updates the UI.** Keep one adapter instance per active configuration and
 let React remove its subscription on unmount. If a credential or agent changes, stop the old

--- a/docs/adapters/gemini-live.mdx
+++ b/docs/adapters/gemini-live.mdx
@@ -112,23 +112,25 @@ declared by each response chunk. An interruption stops all queued audio immediat
 
 `inputVolume` follows the local microphone. `outputVolume` follows the PCM playback analyser.
 
-## Output calibration
+## Directional calibration
 
-Output shaping is optional. Use `outputVolumeCalibration` only when you need provider-specific gain
-or smoothing, and use a getter when values must change during an active session:
+Gemini Live ships with separate microphone and PCM playback profiles. Use partial directional
+overrides only for a materially different audio path, and use a getter when a generated profile
+must update during an active session:
 
 ```tsx
 const adapter = createGeminiLiveAdapter({
   connect,
   outputVolumeCalibration: () => currentCalibration,
-  onOutputVolumeSample: ({ raw, shaped, normalized }) => {
-    console.debug({ raw, shaped, normalized })
+  onOutputVolumeSample: ({ raw, mapped, normalized }) => {
+    console.debug({ raw, mapped, normalized })
   },
 })
 ```
 
-The provider playground exposes the same noise-floor, gain, curve, attack, and release controls for
-calibrating a real conversation before choosing application defaults.
+The provider playground captures silence, quiet, normal, and energetic speech and generates the
+amplitude anchors automatically. See [volume calibration](/guides/volume-calibration) for the
+shared contract and runner workflow.
 
 ## Token handling
 

--- a/docs/adapters/gemini-live.mdx
+++ b/docs/adapters/gemini-live.mdx
@@ -105,7 +105,7 @@ declared by each response chunk. An interruption stops all queued audio immediat
 - token/session connection -> `connecting`
 - active microphone/user speech -> `listening`
 - end of detected user speech or model text work -> `thinking`
-- queued native audio -> `speaking`
+- queued native audio -> `speaking` when the user is not currently speaking
 - interruption, `waitingForInput`, or completed playback -> `listening`
 - Live session failure -> `error`
 - explicit stop or closed connection -> `idle`
@@ -113,6 +113,11 @@ declared by each response chunk. An interruption stops all queued audio immediat
 `inputVolume` follows the local microphone. `outputVolume` follows the PCM playback analyser.
 
 ## Directional calibration
+
+During user interruption, microphone activity keeps the UI in `listening` while buffered response
+chunks arrive and the server stops playback. Those chunks do not switch the animation back to
+`speaking`. Gemini output defaults are calibrated from live native-audio responses independently
+of microphone input; input and output do not share amplitude anchors.
 
 Gemini Live ships with separate microphone and PCM playback profiles. Use partial directional
 overrides only for a materially different audio path, and use a getter when a generated profile

--- a/docs/adapters/livekit.mdx
+++ b/docs/adapters/livekit.mdx
@@ -146,17 +146,14 @@ The adapter reads the agent participant's `lk.agent.state` attribute and maps Li
 LiveKit remote agent audio is attached when available. The recommended browser entrypoint creates
 the SDK audio analysers automatically: the local microphone emits normalized `inputVolume` while
 the agent is listening, and remote agent audio emits normalized `outputVolume` while the agent is
-speaking. The shared `volume` value follows whichever side is active so every orb-ui theme reacts
-correctly. The adapter supplies a speech-oriented decibel range to LiveKit's analyser instead of
-using its narrow defaults, then applies independent attack and release smoothing so normal speech
-retains word-level movement instead of staying near one level.
+speaking. The adapter supplies a speech-oriented decibel range to LiveKit's analyser instead of
+using its narrow defaults, then maps each direction into the standard orb-ui speech envelope.
 
-## Output calibration
+## Directional calibration
 
-The default output curve is tuned against a real LiveKit agent session using the `cloud` theme for
-pronounced word-level movement without pinning the signal at maximum. It is a provider baseline,
-not a guarantee that every theme will feel identical. For a different theme or unusual audio mix,
-pass a partial `outputVolumeCalibration` object, or a getter when controls need to update during a
+LiveKit ships with separate microphone and agent-output profiles. Most applications should use the
+defaults. For an unusual audio path, pass partial `inputVolumeCalibration` or
+`outputVolumeCalibration` overrides, or a getter when a generated profile should update during a
 live session:
 
 ```tsx
@@ -164,13 +161,17 @@ const adapter = createLiveKitAdapter({
   tokenEndpoint: '/api/livekit-token',
   agentName: 'your-agent-name',
   outputVolumeCalibration: {
-    release: 0.12,
+    amplitude: { speechReference: 0.14 },
+    envelope: { fallTimeMs: 300 },
   },
-  onOutputVolumeSample: ({ raw, shaped, normalized }) => {
-    console.debug({ raw, shaped, normalized })
+  onOutputVolumeSample: ({ raw, mapped, normalized }) => {
+    console.debug({ raw, mapped, normalized })
   },
 })
 ```
+
+See [volume calibration](/guides/volume-calibration) for anchor semantics, input/output overrides,
+and the guided profile generator.
 
 ## Token handling
 

--- a/docs/adapters/livekit.mdx
+++ b/docs/adapters/livekit.mdx
@@ -162,7 +162,7 @@ const adapter = createLiveKitAdapter({
   agentName: 'your-agent-name',
   outputVolumeCalibration: {
     amplitude: { speechReference: 0.14 },
-    envelope: { fallTimeMs: 300 },
+    envelope: { fallTimeMs: 550 },
   },
   onOutputVolumeSample: ({ raw, mapped, normalized }) => {
     console.debug({ raw, mapped, normalized })

--- a/docs/adapters/openai-realtime.mdx
+++ b/docs/adapters/openai-realtime.mdx
@@ -94,7 +94,7 @@ const adapter = createOpenAIRealtimeAdapter({
   getClientSecret,
   outputVolumeCalibration: {
     amplitude: { speechReference: 0.12 },
-    envelope: { fallTimeMs: 300 },
+    envelope: { fallTimeMs: 550 },
   },
 })
 ```

--- a/docs/adapters/openai-realtime.mdx
+++ b/docs/adapters/openai-realtime.mdx
@@ -82,23 +82,27 @@ key in browser code or a `VITE_*`/`NEXT_PUBLIC_*` variable.
 The adapter meters the local microphone into `inputVolume` while listening and the remote WebRTC
 track into `outputVolume` while speaking. It also attaches and plays the model audio automatically.
 
-## Output calibration
+## Directional calibration
 
-OpenAI Realtime ships with tuned output defaults for noise floor, gain, curve, attack, and release.
-Most applications should use those defaults. If your audio environment needs different shaping,
-pass a partial `outputVolumeCalibration` object:
+OpenAI Realtime ships with separate input and output defaults that map normal speech to the same
+portable 0–1 distribution as the other adapters. Most applications should use those defaults. If
+your audio path needs different amplitude anchors or envelope timing, pass a partial directional
+override:
 
 ```tsx
 const adapter = createOpenAIRealtimeAdapter({
   getClientSecret,
   outputVolumeCalibration: {
-    release: 0.14,
+    amplitude: { speechReference: 0.12 },
+    envelope: { fallTimeMs: 300 },
   },
 })
 ```
 
 Pass a getter instead of an object to update calibration while a session is active. The optional
-`onOutputVolumeSample` callback reports raw RMS, shaped, and smoothed values for diagnostics.
+`onInputVolumeSample` and `onOutputVolumeSample` callbacks report raw, mapped, and normalized values
+for diagnostics. See [volume calibration](/guides/volume-calibration) for the exact contract and
+guided profile generator.
 
 ## Runtime overrides
 
@@ -122,12 +126,12 @@ then inspect the WebRTC connection and remote track. The adapter creates and pla
 unless a custom runtime override replaces that behavior.
 
 **Listening does not react to speech.** Confirm microphone permission and the requested media
-constraints. Test the raw input diagnostics before changing visual calibration; a silent or wrong
-input device cannot be fixed with gain.
+constraints. Test the raw input diagnostics before changing calibration; a silent or wrong input
+device cannot be fixed with amplitude mapping.
 
-**Speaking motion is too quiet or too aggressive.** Start with the tuned defaults, inspect samples
-with `onOutputVolumeSample`, and change one calibration field at a time. Validate normal speech and
-silence rather than tuning to a single loud clip.
+**Speaking motion is too quiet or too aggressive.** Start with the shipped defaults and use the
+guided calibration runner to capture silence, quiet, normal, and energetic speech. Avoid tuning the
+provider profile to compensate for one theme's visual range.
 
 ## Production checklist
 

--- a/docs/adapters/openai-realtime.mdx
+++ b/docs/adapters/openai-realtime.mdx
@@ -73,14 +73,20 @@ key in browser code or a `VITE_*`/`NEXT_PUBLIC_*` variable.
 
 - WebRTC negotiation -> `connecting`
 - `input_audio_buffer.speech_started` -> `listening`
-- `input_audio_buffer.speech_stopped` and `response.created` -> `thinking`
-- output audio activity -> `speaking`
+- `input_audio_buffer.speech_stopped` and `response.created` -> `thinking` when no output is playing
+- `output_audio_buffer.started` -> `speaking`
 - completed/interrupted output -> `listening`
 - Realtime or WebRTC failure -> `error`
 - explicit stop or closed connection -> `idle`
 
-The adapter meters the local microphone into `inputVolume` while listening and the remote WebRTC
-track into `outputVolume` while speaking. It also attaches and plays the model audio automatically.
+The adapter meters the local microphone into `inputVolume` and the remote WebRTC track into
+`outputVolume`, keeping both envelopes warm during active conversation states. It also attaches
+and plays the model audio automatically.
+
+WebRTC playback start, stop, and clear events take priority over volume-based state inference.
+This prevents a listening flash before the first audio packet or a return to speaking while the
+output envelope fades after playback ends. Detected user speech keeps listening priority during
+interruption. Audio-level inference remains available when playback events are absent.
 
 ## Directional calibration
 

--- a/docs/adapters/overview.mdx
+++ b/docs/adapters/overview.mdx
@@ -25,7 +25,7 @@ including normalized input and output volume when the provider exposes audio.
 
 | Provider        | Browser code you provide                               | What orb-ui owns                                                                  |
 | --------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| Vapi            | A configured `Vapi` client and assistant ID            | Provider event mapping and output metering                                        |
+| Vapi            | A configured `Vapi` client and assistant ID            | Provider event mapping, SDK microphone track metering, and output metering        |
 | ElevenLabs      | The `Conversation` class and agent/session credential  | Session lifecycle, state mapping, playback, and both volume levels                |
 | LiveKit         | A token endpoint and optional agent name               | SDK setup, room lifecycle, agent discovery, playback, and both volume levels      |
 | Pipecat         | A configured `PipecatClient` and its connect callback  | RTVI state mapping, remote playback, and both volume levels                       |

--- a/docs/adapters/pipecat.mdx
+++ b/docs/adapters/pipecat.mdx
@@ -97,29 +97,30 @@ export function PipecatVoiceUI() {
 RTVI `LocalAudioLevel` becomes `inputVolume`; bot `RemoteAudioLevel` becomes `outputVolume`. The
 adapter also meters the `PipecatClient` local and bot `MediaStreamTrack` values directly when they
 are available. That browser fallback keeps both levels working with SmallWebRTC and with transports
-whose RTVI level events are unavailable or sparse. The adapter shapes low raw gain values and
+whose RTVI level events are unavailable or sparse. The adapter maps low raw gain values and
 attaches remote bot audio tracks automatically. Use `isBotParticipant` to filter audio in a
 multi-participant session, or set `playRemoteAudio: false` when your app owns playback.
 
-## Output calibration
+## Directional calibration
 
-The default output curve is tuned against a real Pipecat Cloud agent session using the `cloud`
-theme and works for both RTVI gain events and browser-track RMS samples. It is a provider baseline,
-so a different theme, transport, or audio mix may benefit from a partial override:
+Pipecat ships with separate input and output profiles for both RTVI level events and browser-track
+RMS samples. Most applications should use them unchanged. A custom transport or materially
+different audio path can provide partial directional overrides:
 
 ```tsx
 const adapter = createPipecatAdapter(client, {
   connect,
   outputVolumeCalibration: {
-    gain: 3.5,
+    amplitude: { speechPeak: 0.22 },
   },
-  onOutputVolumeSample: ({ raw, shaped, normalized }) => {
-    console.debug({ raw, shaped, normalized })
+  onOutputVolumeSample: ({ raw, mapped, normalized }) => {
+    console.debug({ raw, mapped, normalized })
   },
 })
 ```
 
-Pass a getter instead of an object to tune the values while a session is active. Set
+Pass a getter instead of an object to apply generated values while a session is active. See
+[volume calibration](/guides/volume-calibration) for the anchor contract and guided runner. Set
 `createAudioContext` to a custom factory—or return `undefined`—when your runtime needs to own or
 disable browser-track metering.
 

--- a/docs/adapters/pipecat.mdx
+++ b/docs/adapters/pipecat.mdx
@@ -88,11 +88,16 @@ export function PipecatVoiceUI() {
 
 - transport initialization/authentication/connection -> `connecting`
 - bot ready and user speaking -> `listening`
-- user stopped speaking, LLM started, or TTS started -> `thinking`
+- user stopped speaking, LLM started, or TTS started -> `thinking` (generation events do not
+  interrupt an active `speaking` state)
 - bot started speaking -> `speaking`
 - bot stopped speaking -> `listening`
 - client, message, or device error -> `error`
 - disconnected -> `idle`
+
+LLM and TTS generation can overlap playback of an earlier sentence. Bot playback events retain
+the `speaking` state during that work, so the animation continues to follow output volume. User
+speech can still interrupt the bot and return the UI to `listening`.
 
 RTVI `LocalAudioLevel` becomes `inputVolume`; bot `RemoteAudioLevel` becomes `outputVolume`. The
 adapter also meters the `PipecatClient` local and bot `MediaStreamTrack` values directly when they

--- a/docs/adapters/vapi.mdx
+++ b/docs/adapters/vapi.mdx
@@ -79,9 +79,15 @@ The core mapping is:
 | `call-end`     | `idle`       |
 | `error`        | `error`      |
 
-The adapter smooths Vapi's assistant volume events before emitting `outputVolume`. It also
+The adapter maps Vapi's assistant volume events into the standard stable `outputVolume` envelope.
+It also
 debounces short speaking-to-listening changes so normal turn boundaries do not create distracting
 visual flicker.
+
+Most applications should use the shipped output profile. For a custom Vapi audio path, the adapter
+accepts `outputVolumeCalibration` and `onOutputVolumeSample`. See
+[volume calibration](/guides/volume-calibration) for the anchor semantics and guided profile
+generator.
 
 ## Accessibility
 

--- a/docs/adapters/vapi.mdx
+++ b/docs/adapters/vapi.mdx
@@ -64,9 +64,11 @@ The adapter maps Vapi conversation lifecycle events into orb-ui state changes. T
 - errors
 
 Vapi assistant audio levels are emitted as `outputVolume` while the assistant is speaking.
-The Vapi web SDK does not currently expose local microphone input levels through the
-adapter event stream, so this adapter does not emit `inputVolume` while listening. If your
-app already meters the microphone separately, pass a controlled `signal` to `Orb`.
+Microphone `inputVolume` comes from the existing local audio track exposed by the SDK's public
+`getDailyCallObject()` method. The adapter does not request a second microphone stream or stop
+SDK-owned tracks. It follows track replacement and mute, and releases its meter when the call
+ends, errors, or the subscriber disconnects. Clients without this optional method retain assistant
+output metering and report zero input.
 
 The core mapping is:
 
@@ -84,8 +86,10 @@ It also
 debounces short speaking-to-listening changes so normal turn boundaries do not create distracting
 visual flicker.
 
-Most applications should use the shipped output profile. For a custom Vapi audio path, the adapter
-accepts `outputVolumeCalibration` and `onOutputVolumeSample`. See
+Most applications should use the shipped directional profiles. For a custom Vapi audio path, the
+adapter accepts `inputVolumeCalibration`, `outputVolumeCalibration`, `onInputVolumeSample`, and
+`onOutputVolumeSample`. Input diagnostics measure waveform RMS; output diagnostics report Vapi's
+remote audio levels. `createAudioContext` can customize or disable the microphone meter. See
 [volume calibration](/guides/volume-calibration) for the anchor semantics and guided profile
 generator.
 
@@ -98,7 +102,7 @@ When an adapter or `onStart`/`onStop` handler is provided, clickable `circle` an
 Use controlled mode if your app wraps Vapi in its own session layer or combines Vapi with custom state. The Orb component does not need to own the provider SDK if your app already knows the voice signal.
 
 ```tsx
-<Orb signal={{ state: voiceState, outputVolume }} theme="circle" />
+<Orb signal={{ state: voiceState, inputVolume, outputVolume }} theme="circle" />
 ```
 
 Controlled mode is the better fit when you combine Vapi with a separate microphone meter, tool
@@ -110,9 +114,9 @@ session layer and pass one normalized `OrbSignal` to the UI.
 **The orb never leaves idle.** Make sure the adapter and the code starting the call share the same
 Vapi client instance. The adapter listens for lifecycle events on that object.
 
-**Listening has little or no audio motion.** The current Vapi event stream used by this adapter
-provides assistant output levels, not the local microphone level. This is expected. Supply a custom
-`inputVolume` through controlled mode if microphone-reactive listening is important to the design.
+**Listening has little or no audio motion.** Confirm that the Vapi client exposes
+`getDailyCallObject()`, the microphone is enabled, and Web Audio is available. SDK wrappers that
+hide that method can expose it or supply `inputVolume` through controlled mode.
 
 **The interface starts multiple calls.** Use either the interactive orb or your own start control
 as the primary action. When the product owns the controls, set `interactive={false}`.
@@ -125,7 +129,7 @@ adjacent recovery copy rather than relying on the visual alone.
 
 - The Vapi public key and assistant configuration are appropriate for browser use.
 - One stable client and adapter instance owns the current call.
-- The missing local input meter is acceptable or supplied through controlled mode.
+- The SDK's local microphone track is available and produces input levels while listening.
 - Permission and provider errors have labeled retry actions.
 - Interactive behavior is disabled when separate call controls are present.
 - Start, stop, interruption, failure, and restart are tested in the real browser.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,6 +93,7 @@
         "pages": [
           "guides/voice-agent-ui",
           "guides/signal-based-voice-agent-ui",
+          "guides/volume-calibration",
           "examples/voice-orb-ui",
           "guides/voice-agent-platforms",
           "guides/ai-voice-sales-agents",

--- a/docs/examples/voice-orb-ui.mdx
+++ b/docs/examples/voice-orb-ui.mdx
@@ -9,7 +9,7 @@ The orb is the visible state layer for a voice agent. It should communicate acti
 import { Orb } from 'orb-ui'
 
 export function VoiceOrbExample() {
-  return <Orb state="listening" volume={0.45} theme="circle" size={260} />
+  return <Orb signal={{ state: 'listening', inputVolume: 0.45 }} theme="circle" size={260} />
 }
 ```
 
@@ -32,7 +32,11 @@ export function OrbStatePreview() {
 
   return (
     <section>
-      <Orb state={state} volume={state === 'idle' ? 0 : 0.45} theme="circle" interactive={false} />
+      <Orb
+        signal={{ state, inputVolume: state === 'listening' ? 0.45 : 0 }}
+        theme="circle"
+        interactive={false}
+      />
       <label>
         Voice state
         <select value={state} onChange={(event) => setState(event.target.value as OrbState)}>

--- a/docs/guides/signal-based-voice-agent-ui.mdx
+++ b/docs/guides/signal-based-voice-agent-ui.mdx
@@ -17,7 +17,6 @@ type OrbState = 'idle' | 'connecting' | 'listening' | 'thinking' | 'speaking' | 
 
 interface OrbSignal {
   state: OrbState
-  volume?: number
   inputVolume?: number
   outputVolume?: number
   error?: unknown
@@ -71,10 +70,9 @@ Normalize audio levels to `0`–`1`. `inputVolume` represents the user's microph
 represents assistant playback. Keeping them separate prevents microphone noise from animating the
 orb while the assistant is speaking.
 
-`Orb` selects `inputVolume` in `listening` and `outputVolume` in `speaking`. The legacy `volume`
-field is a fallback for integrations with only one meter. The explicit `volume` prop has the
-highest priority when supplied. Outside listening and speaking, volume falls back to `signal.volume`
-or zero.
+`Orb` selects `inputVolume` in `listening` and `outputVolume` in `speaking`. It uses zero outside
+those states. There is no directionless `volume` field: a stable signal contract lets every theme
+interpret the same input and output semantics.
 
 Clamp provider values before emitting them:
 
@@ -82,8 +80,10 @@ Clamp provider values before emitting them:
 const normalizeVolume = (value: number) => Math.max(0, Math.min(value, 1))
 ```
 
-Raw browser microphone measurements may need additional noise gating, smoothing, or calibration.
-Do that at the adapter boundary so themes receive stable normalized data.
+Raw provider measurements need amplitude mapping and envelope processing. Do that at the adapter
+boundary so themes receive a stable normalized speech envelope. Built-in adapters ship with
+directional defaults; [volume calibration](/guides/volume-calibration) documents the exact anchors,
+timing semantics, and guided calibration runner.
 
 ## Adapter mode versus controlled mode
 
@@ -105,9 +105,9 @@ export function VoiceStatus({ signal }: { signal: OrbSignal }) {
 }
 ```
 
-The `state` and `volume` props can override signal or adapter values, but prefer one ownership model
-per component. Controlled mode is the shortest route for a one-off integration. An adapter becomes
-valuable when the mapping and cleanup logic is reused.
+The `state` prop can override signal or adapter state, but prefer one ownership model per component.
+Controlled mode is the shortest route for a one-off integration. An adapter becomes valuable when
+the mapping, calibration, and cleanup logic is reused.
 
 ## Build a real custom adapter
 

--- a/docs/guides/voice-agent-ui.mdx
+++ b/docs/guides/voice-agent-ui.mdx
@@ -63,7 +63,7 @@ Controlled mode is especially useful for teams experimenting with OpenAI Realtim
 import { Orb } from 'orb-ui'
 
 export function VoiceAgentStatus({ state, volume }) {
-  return <Orb state={state} volume={volume} theme="circle" size={240} />
+  return <Orb signal={{ state, inputVolume: volume }} theme="circle" size={240} />
 }
 ```
 

--- a/docs/guides/volume-calibration.mdx
+++ b/docs/guides/volume-calibration.mdx
@@ -53,13 +53,18 @@ value mapped to normalized `0.5`. `speechPeak` is the raw value mapped to `1`. o
 curve between these anchors, so consumers do not have to tune an unexplained exponent.
 
 `riseTimeMs` and `fallTimeMs` are the time required for the normalized envelope to move 90% toward
-a new value. Shipped profiles currently use `100ms` rise and `250ms` fall. Processing is based on
+a new value. Shipped profiles currently use `100ms` rise and `400ms` fall. Processing is based on
 elapsed time rather than callback count, so providers with different meter rates still behave
 consistently.
 
 These times belong to signal normalization, not theme choreography. They remove provider jitter and
 produce a portable speech envelope. A theme can add its own visual response, easing, state
 transition, and autonomous motion after normalization.
+
+Built-in adapters keep every available directional envelope warm while a session is active.
+Changing between `listening`, `thinking`, and `speaking` selects a direction for rendering; it does
+not reset an envelope to an artificial zero. Disconnecting, stopping, or entering an error state
+does.
 
 ## Override a built-in profile
 
@@ -77,7 +82,7 @@ const adapter = createOpenAIRealtimeAdapter({
       speechReference: 0.12,
       speechPeak: 0.28,
     },
-    envelope: { fallTimeMs: 300 },
+    envelope: { fallTimeMs: 550 },
   },
 })
 ```

--- a/docs/guides/volume-calibration.mdx
+++ b/docs/guides/volume-calibration.mdx
@@ -1,0 +1,140 @@
+---
+title: Normalize Voice Volume Across Providers
+description: Understand orb-ui's directional 0–1 speech envelope, provider calibration profiles, timing semantics, diagnostics, and guided calibration runner.
+---
+
+Every orb-ui theme consumes the same signal: a stable normalized speech envelope from `0` to `1`.
+The provider adapter is responsible for producing it. Themes do not know whether a raw measurement
+came from RMS audio, an SDK gain event, or a provider-specific volume callback.
+
+```text
+raw provider level
+  -> provider artifact cleanup
+  -> amplitude anchors
+  -> stable rise/fall envelope
+  -> inputVolume or outputVolume (0–1)
+  -> theme response
+```
+
+Input and output have separate profiles because microphone and playback measurements often use
+different sources and distributions. Built-in adapters ship with defaults for both directions when
+the provider exposes both. Vapi currently exposes assistant output only.
+
+## The 0–1 contract
+
+- `0` means silence or no meaningful activity.
+- `0.5` means ordinary conversational speech.
+- `1` means a strong, uncommon speech peak.
+- `inputVolume` is active while the user is being heard.
+- `outputVolume` is active while the assistant is speaking.
+
+The distribution matters as much as the endpoints. Normal speech should move through the middle of
+the range instead of remaining near zero or saturating at one. This lets a theme or animation preset
+work consistently across providers.
+
+## Calibration profile
+
+```ts
+interface VolumeCalibration {
+  amplitude: {
+    silenceFloor: number
+    speechReference: number
+    speechPeak: number
+  }
+  envelope: {
+    riseTimeMs: number
+    fallTimeMs: number
+  }
+}
+```
+
+`silenceFloor` is the raw value at or below which the output is zero. `speechReference` is the raw
+value mapped to normalized `0.5`. `speechPeak` is the raw value mapped to `1`. orb-ui derives the
+curve between these anchors, so consumers do not have to tune an unexplained exponent.
+
+`riseTimeMs` and `fallTimeMs` are the time required for the normalized envelope to move 90% toward
+a new value. Shipped profiles currently use `100ms` rise and `250ms` fall. Processing is based on
+elapsed time rather than callback count, so providers with different meter rates still behave
+consistently.
+
+These times belong to signal normalization, not theme choreography. They remove provider jitter and
+produce a portable speech envelope. A theme can add its own visual response, easing, state
+transition, and autonomous motion after normalization.
+
+## Override a built-in profile
+
+Most applications should keep the shipped defaults. If a custom audio path has a different raw
+distribution, pass partial overrides for each affected direction:
+
+```tsx
+const adapter = createOpenAIRealtimeAdapter({
+  getClientSecret,
+  inputVolumeCalibration: {
+    amplitude: { silenceFloor: 0.004 },
+  },
+  outputVolumeCalibration: {
+    amplitude: {
+      speechReference: 0.12,
+      speechPeak: 0.28,
+    },
+    envelope: { fallTimeMs: 300 },
+  },
+})
+```
+
+Pass a getter to apply a generated profile without restarting the adapter. Diagnostic callbacks
+report each stage:
+
+```tsx
+const adapter = createOpenAIRealtimeAdapter({
+  getClientSecret,
+  outputVolumeCalibration: () => currentProfile.output,
+  onOutputVolumeSample: ({ raw, mapped, normalized, elapsedMs }) => {
+    console.debug({ raw, mapped, normalized, elapsedMs })
+  },
+})
+```
+
+`raw` is the provider measurement, `mapped` is the amplitude-mapped value before temporal
+processing, and `normalized` is the stable envelope emitted as `outputVolume`.
+
+## Generate a profile with the guided runner
+
+The provider QA playground generates amplitude anchors instead of asking you to tune sliders:
+
+1. Run `pnpm build` and `pnpm dev:demo`.
+2. Open `/provider-playground` and configure the provider.
+3. Start a real session and select input or output.
+4. Capture silence, quiet speech, normal speech, and energetic speech.
+5. Generate the profile and inspect its mapped distribution.
+6. Repeat for the other direction and compare themes using the same generated profile.
+
+The runner stores generated profiles locally in that browser and applies them to the active session
+through calibration getters. It reports mapped quiet, normal, and energetic medians so a maintainer
+can verify that normal speech centers around `0.5` and energetic speech uses the upper range. Reset
+restores the shipped baseline for the selected direction.
+
+Use the runner when validating a provider default or a materially different audio pipeline. It is
+not intended as an installation step for every application.
+
+## Calibration API
+
+`orb-ui/adapters` exports the reusable pieces used by the built-in adapters and playground:
+
+```ts
+import {
+  PROVIDER_VOLUME_CALIBRATIONS,
+  createVolumeNormalizer,
+  fitVolumeCalibration,
+  mapVolumeAmplitude,
+} from 'orb-ui/adapters'
+```
+
+Custom adapters can use `createVolumeNormalizer` to emit the same stable envelope. The calibration
+fitter accepts four raw sample arrays and returns both a generated profile and distribution metrics.
+
+## What not to calibrate here
+
+Do not tune provider profiles to make one theme larger, faster, or more dramatic. Provider
+calibration standardizes measurement semantics. Theme-specific size, deformation, visual response,
+easing, and transition behavior belong to theme configuration.

--- a/docs/guides/volume-calibration.mdx
+++ b/docs/guides/volume-calibration.mdx
@@ -18,7 +18,7 @@ raw provider level
 
 Input and output have separate profiles because microphone and playback measurements often use
 different sources and distributions. Built-in adapters ship with defaults for both directions when
-the provider exposes both. Vapi currently exposes assistant output only.
+the provider exposes both. Vapi meters input from its SDK-owned local microphone track.
 
 ## The 0–1 contract
 

--- a/docs/guides/volume-calibration.mdx
+++ b/docs/guides/volume-calibration.mdx
@@ -108,7 +108,7 @@ processing, and `normalized` is the stable envelope emitted as `outputVolume`.
 The provider QA playground generates amplitude anchors instead of asking you to tune sliders:
 
 1. Run `pnpm build` and `pnpm dev:demo`.
-2. Open `/provider-playground` and configure the provider.
+2. Open `/playground` and configure the provider.
 3. Start a real session and select input or output.
 4. Capture silence, quiet speech, normal speech, and energetic speech.
 5. Generate the profile and inspect its mapped distribution.
@@ -121,6 +121,26 @@ restores the shipped baseline for the selected direction.
 
 Use the runner when validating a provider default or a materially different audio pipeline. It is
 not intended as an installation step for every application.
+
+## Repeatable provider QA
+
+Compare normalized activity, not equal raw numbers. ElevenLabs client 1.9.0 averages voice-band
+frequency bins. LiveKit client 2.20.0 computes a different frequency-bin measure with the adapter's
+analyser settings. Pipecat's browser track meters, OpenAI Realtime, and Gemini Live use waveform
+RMS. A raw value of `0.2` therefore does not represent the same audio level in every adapter.
+
+For repeatable microphone tests, feed the same recorded speech at quiet, normal, and louder gains
+through the browser's microphone capture path, with silence between passages. Keep the SDK's
+normal echo cancellation, noise suppression, and automatic gain control settings, and measure the
+captured track alongside the SDK's raw level. Browser gain control can boost quiet speech and
+compress the difference between source levels. A digital recording tests that processing path;
+physical microphones, room noise, and speaking distance still vary.
+
+Record actual provider output as well as raw, mapped, and normalized samples and state changes.
+Check silence, ordinary speech, peaks, pauses, interruption, and restart. Replay the same traces
+through proposed profiles and themes so audio differences cannot hide a regression. Validate a
+candidate with another voice or phrase before changing a shipped default. Clear saved playground
+profiles when checking defaults, and keep credentials out of recordings and trace fixtures.
 
 ## Calibration API
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -18,7 +18,7 @@ Use orb-ui when you want users to understand whether a voice agent is idle, conn
 import { Orb } from 'orb-ui'
 
 export function VoiceAgentStatus({ state, volume }) {
-  return <Orb state={state} volume={volume} theme="circle" />
+  return <Orb signal={{ state, inputVolume: volume }} theme="circle" />
 }
 ```
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -31,7 +31,7 @@ Controlled mode is the universal fallback. Use it when your app already owns the
 import { Orb } from 'orb-ui'
 
 export function VoiceAgentStatus({ state, volume }) {
-  return <Orb state={state} volume={volume} theme="circle" size={240} />
+  return <Orb signal={{ state, inputVolume: volume }} theme="circle" size={240} />
 }
 ```
 

--- a/docs/reference/orb-component.mdx
+++ b/docs/reference/orb-component.mdx
@@ -3,11 +3,12 @@ title: Orb component API
 description: Reference for the Orb component props, states, themes, and adapter interface.
 ---
 
-`Orb` is the main orb-ui component. It can run in controlled mode with explicit `state` and `volume` props, richer `signal` objects, or through a provider adapter.
+`Orb` is the main orb-ui component. It can run in controlled mode with a directional `signal`, or
+through a provider adapter.
 
 ```tsx
 import { Orb } from 'orb-ui'
-;<Orb state="listening" volume={0.4} theme="circle" size={240} />
+;<Orb signal={{ state: 'listening', inputVolume: 0.4 }} theme="circle" size={240} />
 ```
 
 ## Props
@@ -16,7 +17,6 @@ import { Orb } from 'orb-ui'
 | ------------- | ------------------ | ---------------------- | ------------------------------------------------------------------ |
 | `signal`      | `OrbSignal`        | adapter signal         | Current voice signal with state, input volume, and output volume.  |
 | `state`       | `OrbState`         | signal state or `idle` | Current voice agent state. Overrides signal and adapter state.     |
-| `volume`      | `number`           | signal volume or `0`   | Audio volume from `0` to `1`. Overrides signal and adapter volume. |
 | `adapter`     | `OrbAdapter`       | none                   | Provider adapter that subscribes to normalized signal updates.     |
 | `theme`       | `OrbTheme`         | `debug`                | Visual theme: `debug`, `circle`, `bars`, `cloud`, or `radial`.     |
 | `size`        | `number`           | `200`                  | Component size in pixels.                                          |
@@ -74,7 +74,6 @@ session controller, so external buttons can call its existing lifecycle methods.
 ```ts
 interface OrbSignal {
   state: OrbState
-  volume?: number
   inputVolume?: number
   outputVolume?: number
   error?: unknown
@@ -93,6 +92,26 @@ Adapters normalize provider SDK events into orb-ui signals. If a provider is not
 <Orb signal={{ state: 'listening', inputVolume: 0.35 }} />
 <Orb signal={{ state: 'speaking', outputVolume: 0.72 }} />
 ```
+
+`inputVolume` and `outputVolume` are stable normalized speech envelopes from `0` to `1`. `Orb`
+reads input while `state` is `listening`, output while `state` is `speaking`, and zero in other
+states. See [volume calibration](/guides/volume-calibration) for the provider mapping contract.
+
+## Migrating from `volume`
+
+The ambiguous `volume` prop and `OrbSignal.volume` field have been removed. Put the value on the
+direction that owns it:
+
+```tsx
+// Before
+<Orb state="speaking" volume={level} />
+
+// After
+<Orb signal={{ state: 'speaking', outputVolume: level }} />
+```
+
+For a custom adapter, emit `inputVolume` for microphone activity and `outputVolume` for assistant
+playback. Provider adapters already do this and ship with directional calibration defaults.
 
 ## Migrating callback-object adapters
 

--- a/docs/themes/voice-states.mdx
+++ b/docs/themes/voice-states.mdx
@@ -62,7 +62,7 @@ layout. Call `adapter.start()` and `adapter.stop()` from those controls.
 Use `circle` when the voice agent is a primary assistant surface. It reads as an orb, status indicator, and voice presence at the same time.
 
 ```tsx
-<Orb theme="circle" state="listening" volume={0.42} />
+<Orb theme="circle" signal={{ state: 'listening', inputVolume: 0.42 }} />
 ```
 
 ## Bars
@@ -70,7 +70,7 @@ Use `circle` when the voice agent is a primary assistant surface. It reads as an
 Use `bars` when you want a waveform-like audio visualization.
 
 ```tsx
-<Orb theme="bars" state="speaking" volume={0.72} />
+<Orb theme="bars" signal={{ state: 'speaking', outputVolume: 0.72 }} />
 ```
 
 ## Debug

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@playwright/test": "1.61.1",
     "@types/react": "^18.3.29",
     "@types/react-dom": "^18.3.7",
-    "@vapi-ai/web": "2.5.2",
+    "@vapi-ai/web": "2.7.0",
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^10.4.0",
     "globals": "^17.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.29)
       '@vapi-ai/web':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.7.0
+        version: 2.7.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.14(@types/node@26.1.1))
@@ -92,8 +92,8 @@ importers:
         specifier: 1.10.5
         version: 1.10.5(@pipecat-ai/client-js@1.12.0)
       '@vapi-ai/web':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.7.0
+        version: 2.7.0
       livekit-client:
         specifier: 2.20.0
         version: 2.20.0(@types/dom-mediacapture-record@1.0.22)
@@ -246,10 +246,10 @@ packages:
         integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
       }
 
-  '@daily-co/daily-js@0.85.0':
+  '@daily-co/daily-js@0.87.0':
     resolution:
       {
-        integrity: sha512-lpl111ZWNTUWDnwYcPuNi9PGJPbLCeCw6LzmEY40nG0hv1jg5JLVW8Rq3Cj/+lOCP6W6h4PXm211ss0FFnxITQ==,
+        integrity: sha512-hWHdBDvJwDeg8unz+XG9hD7xamuFi5Jmsk89ASATKL4fdTDHplpxi4PG9aaPXzBZYYLTjuxUje1K7B5uUR+gzw==,
       }
     engines: { node: '>=10.0.0' }
 
@@ -1193,10 +1193,10 @@ packages:
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@vapi-ai/web@2.5.2':
+  '@vapi-ai/web@2.7.0':
     resolution:
       {
-        integrity: sha512-mT4DjApi0/0+EK77h2xOLq3qVBa7rv3JNQ+gFWuhFE4YdGYxI51+fn8bQI9N535+zU/Z4jFKXotdBHQJ3filHA==,
+        integrity: sha512-eDrEzZwRety39pCA2DyY8kvAAXnWtVXoshbX/FFf0WGDnWGvrqlX3fkK7jJrls3IpXatEf60FtZZYDhxNNEpNQ==,
       }
     engines: { node: '>=18.0.0' }
 
@@ -3209,7 +3209,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@daily-co/daily-js@0.85.0':
+  '@daily-co/daily-js@0.87.0':
     dependencies:
       '@babel/runtime': 7.29.2
       '@sentry/browser': 8.55.2
@@ -3728,9 +3728,9 @@ snapshots:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
-  '@vapi-ai/web@2.5.2':
+  '@vapi-ai/web@2.7.0':
     dependencies:
-      '@daily-co/daily-js': 0.85.0
+      '@daily-co/daily-js': 0.87.0
       events: 3.3.0
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.14(@types/node@26.1.1))':

--- a/src/adapters/adapters.test.ts
+++ b/src/adapters/adapters.test.ts
@@ -94,12 +94,18 @@ describe('Vapi adapter signals', () => {
     expect(lastSignal(signals).state).toBe('speaking')
     expect(lastSignal(signals).outputVolume).toBeGreaterThan(0)
 
+    const speakingVolume = lastSignal(signals).outputVolume ?? 0
     client.emit('speech-end')
-    expect(lastSignal(signals)).toMatchObject({
-      outputVolume: 0,
-    })
+    expect(lastSignal(signals)).toMatchObject({ state: 'speaking' })
+    expect(lastSignal(signals).outputVolume).toBe(speakingVolume)
 
-    vi.advanceTimersByTime(350)
+    vi.advanceTimersByTime(175)
+    animationFrame.flush()
+    expect(lastSignal(signals).state).toBe('speaking')
+    expect(lastSignal(signals).outputVolume).toBeLessThan(speakingVolume)
+    expect(lastSignal(signals).outputVolume).toBeGreaterThan(0)
+
+    vi.advanceTimersByTime(175)
     expect(lastSignal(signals)).toMatchObject({
       state: 'listening',
       outputVolume: 0,
@@ -191,17 +197,35 @@ describe('ElevenLabs adapter signals', () => {
     expect(lastSignal(signals)).toMatchObject({
       state: 'listening',
       inputVolume: expect.any(Number),
+      outputVolume: expect.any(Number),
     })
     expect(lastSignal(signals).inputVolume).toBeGreaterThan(0)
+    expect(lastSignal(signals).outputVolume).toBeGreaterThan(0)
 
+    const listeningSignal = lastSignal(signals)
     sessionOptions?.onModeChange?.({ mode: 'speaking' })
+    expect(lastSignal(signals)).toMatchObject({
+      state: 'speaking',
+      inputVolume: listeningSignal.inputVolume,
+      outputVolume: listeningSignal.outputVolume,
+    })
     vi.advanceTimersByTime(33)
 
     expect(lastSignal(signals)).toMatchObject({
       state: 'speaking',
+      inputVolume: expect.any(Number),
       outputVolume: expect.any(Number),
     })
+    expect(lastSignal(signals).inputVolume).toBeGreaterThan(0)
     expect(lastSignal(signals).outputVolume).toBeGreaterThan(0)
+
+    const speakingSignal = lastSignal(signals)
+    sessionOptions?.onModeChange?.({ mode: 'listening' })
+    expect(lastSignal(signals)).toMatchObject({
+      state: 'listening',
+      inputVolume: speakingSignal.inputVolume,
+      outputVolume: speakingSignal.outputVolume,
+    })
 
     await adapter.stop()
 

--- a/src/adapters/adapters.test.ts
+++ b/src/adapters/adapters.test.ts
@@ -96,14 +96,12 @@ describe('Vapi adapter signals', () => {
 
     client.emit('speech-end')
     expect(lastSignal(signals)).toMatchObject({
-      volume: 0,
       outputVolume: 0,
     })
 
     vi.advanceTimersByTime(350)
     expect(lastSignal(signals)).toMatchObject({
       state: 'listening',
-      volume: 0,
       outputVolume: 0,
     })
 
@@ -192,25 +190,24 @@ describe('ElevenLabs adapter signals', () => {
 
     expect(lastSignal(signals)).toMatchObject({
       state: 'listening',
-      volume: 0.4,
-      inputVolume: 0.4,
+      inputVolume: expect.any(Number),
     })
+    expect(lastSignal(signals).inputVolume).toBeGreaterThan(0)
 
     sessionOptions?.onModeChange?.({ mode: 'speaking' })
     vi.advanceTimersByTime(33)
 
     expect(lastSignal(signals)).toMatchObject({
       state: 'speaking',
-      volume: 0.8,
-      outputVolume: 0.8,
+      outputVolume: expect.any(Number),
     })
+    expect(lastSignal(signals).outputVolume).toBeGreaterThan(0)
 
     await adapter.stop()
 
     expect(conversation.endSession).toHaveBeenCalledOnce()
     expect(lastSignal(signals)).toMatchObject({
       state: 'idle',
-      volume: 0,
       inputVolume: 0,
       outputVolume: 0,
     })
@@ -346,8 +343,9 @@ describe('ElevenLabs adapter signals', () => {
 
     expect(lastSignal(firstSignals)).toMatchObject({
       state: 'listening',
-      inputVolume: 0.4,
+      inputVolume: expect.any(Number),
     })
+    expect(lastSignal(firstSignals).inputVolume).toBeGreaterThan(0)
 
     unsubscribe()
     inputVolume = 0.3
@@ -364,7 +362,8 @@ describe('ElevenLabs adapter signals', () => {
 
     expect(lastSignal(secondSignals)).toMatchObject({
       state: 'listening',
-      inputVolume: 0.6,
+      inputVolume: expect.any(Number),
     })
+    expect(lastSignal(secondSignals).inputVolume).toBeGreaterThan(0)
   })
 })

--- a/src/adapters/adapters.test.ts
+++ b/src/adapters/adapters.test.ts
@@ -69,6 +69,89 @@ afterEach(() => {
 })
 
 describe('Vapi adapter signals', () => {
+  it('meters delayed and replaced SDK microphone tracks without owning their lifecycle', async () => {
+    vi.useFakeTimers()
+    const client = new FakeVapiClient()
+    const makeTrack = () => ({ enabled: true, muted: false, readyState: 'live', stop: vi.fn() })
+    const first = makeTrack()
+    const second = makeTrack()
+    let localAudio: { state?: string; persistentTrack?: ReturnType<typeof makeTrack> } | undefined
+    const call = { participants: () => ({ local: { tracks: { audio: localAudio } } }) }
+    Object.assign(client, { getDailyCallObject: () => call })
+    vi.stubGlobal(
+      'MediaStream',
+      class {
+        constructor(public tracks: unknown[]) {}
+      },
+    )
+    const contexts: {
+      close: ReturnType<typeof vi.fn>
+      source: { disconnect: ReturnType<typeof vi.fn> }
+    }[] = []
+    const createAudioContext = vi.fn(() => {
+      const source = { connect: vi.fn(), disconnect: vi.fn() }
+      const context = {
+        state: 'running',
+        close: vi.fn(async () => undefined),
+        source,
+        createMediaStreamSource: () => source,
+        createAnalyser: () => ({
+          fftSize: 512,
+          smoothingTimeConstant: 0,
+          getFloatTimeDomainData: (samples: Float32Array) => samples.fill(0.1),
+          disconnect: vi.fn(),
+        }),
+      }
+      contexts.push(context)
+      return context as unknown as AudioContext
+    })
+    const samples = vi.fn()
+    const adapter = createVapiAdapter(client as unknown as VapiClientLike, {
+      createAudioContext,
+      onInputVolumeSample: samples,
+    })
+    const signals: OrbSignal[] = []
+    const unsubscribe = adapter.subscribe((signal) => signals.push(signal))
+    client.emit('call-start')
+    vi.advanceTimersByTime(200)
+    expect(createAudioContext).not.toHaveBeenCalled()
+
+    localAudio = { state: 'playable', persistentTrack: first }
+    vi.advanceTimersByTime(300)
+    expect(lastSignal(signals).inputVolume).toBeGreaterThan(0.4)
+    expect(samples.mock.lastCall?.[0].raw).toBeCloseTo(0.1)
+    expect(createAudioContext).toHaveBeenCalledTimes(1)
+
+    localAudio = { state: 'playable', persistentTrack: second }
+    vi.advanceTimersByTime(200)
+    expect(contexts[0].close).toHaveBeenCalledOnce()
+    expect(contexts[0].source.disconnect).toHaveBeenCalledOnce()
+    expect(createAudioContext).toHaveBeenCalledTimes(2)
+    second.enabled = false
+    vi.advanceTimersByTime(100)
+    expect(lastSignal(signals).inputVolume).toBe(0)
+    expect(contexts[1].close).toHaveBeenCalledOnce()
+
+    second.enabled = true
+    vi.advanceTimersByTime(200)
+    expect(lastSignal(signals).inputVolume).toBeGreaterThan(0)
+    await adapter.stop?.()
+    expect(lastSignal(signals)).toMatchObject({ state: 'idle', inputVolume: 0, outputVolume: 0 })
+    const stoppedCount = signals.length
+    vi.advanceTimersByTime(500)
+    expect(signals).toHaveLength(stoppedCount)
+
+    client.emit('call-start')
+    vi.advanceTimersByTime(200)
+    const count = signals.length
+    unsubscribe()
+    vi.advanceTimersByTime(500)
+    expect(signals).toHaveLength(count)
+    expect(contexts.every((context) => context.close.mock.calls.length === 1)).toBe(true)
+    expect(first.stop).not.toHaveBeenCalled()
+    expect(second.stop).not.toHaveBeenCalled()
+  })
+
   it('emits output volume while speaking and cancels interpolation on unsubscribe', async () => {
     vi.useFakeTimers()
     const animationFrame = installAnimationFrameStub()

--- a/src/adapters/audio-level.test.ts
+++ b/src/adapters/audio-level.test.ts
@@ -1,38 +1,80 @@
 import { describe, expect, it } from 'vitest'
-import { calibrateOutputVolume } from './audio-level'
+import {
+  calibrateVolume,
+  createVolumeNormalizer,
+  fitVolumeCalibration,
+  mapVolumeAmplitude,
+  type VolumeCalibration,
+} from './audio-level'
 
-describe('calibrateOutputVolume', () => {
-  it('applies a noise floor, gain, curve, and independent attack/release rates', () => {
-    const calibration = {
-      noiseFloor: 0.005,
-      gain: 4,
-      exponent: 0.8,
-      attack: 0.5,
-      release: 0.1,
-    }
+const CALIBRATION: VolumeCalibration = {
+  amplitude: {
+    silenceFloor: 0.01,
+    speechReference: 0.21,
+    speechPeak: 0.81,
+  },
+  envelope: {
+    riseTimeMs: 100,
+    fallTimeMs: 250,
+  },
+}
 
-    expect(calibrateOutputVolume(0.004, 0, calibration)).toEqual({
-      raw: 0.004,
-      shaped: 0,
-      normalized: 0,
-    })
-
-    const attack = calibrateOutputVolume(0.05, 0, calibration)
-    expect(attack.shaped).toBeGreaterThan(0.2)
-    expect(attack.normalized).toBeCloseTo(attack.shaped * 0.5)
-
-    const release = calibrateOutputVolume(0, attack.normalized, calibration)
-    expect(release.normalized).toBeCloseTo(attack.normalized * 0.9)
+describe('volume calibration', () => {
+  it('maps silence, ordinary speech, and strong peaks to semantic anchors', () => {
+    expect(mapVolumeAmplitude(0.005, CALIBRATION.amplitude)).toBe(0)
+    expect(mapVolumeAmplitude(0.21, CALIBRATION.amplitude)).toBeCloseTo(0.5)
+    expect(mapVolumeAmplitude(0.81, CALIBRATION.amplitude)).toBe(1)
   })
 
-  it('reads live calibration values from a getter', () => {
-    let gain = 2
-    const getCalibration = () => ({ gain })
+  it('uses elapsed-time rise and fall durations independent of sample rate', () => {
+    const oneRise = calibrateVolume(0.81, 0, 100, CALIBRATION)
+    const halfRise = calibrateVolume(0.81, 0, 50, CALIBRATION)
+    const twoHalfRises = calibrateVolume(0.81, halfRise.normalized, 50, CALIBRATION)
+    expect(oneRise.normalized).toBeCloseTo(0.9)
+    expect(twoHalfRises.normalized).toBeCloseTo(oneRise.normalized)
 
-    const quieter = calibrateOutputVolume(0.05, 0, getCalibration)
-    gain = 8
-    const louder = calibrateOutputVolume(0.05, 0, getCalibration)
+    const release = calibrateVolume(0, 1, 250, CALIBRATION)
+    expect(release.normalized).toBeCloseTo(0.1)
+  })
+
+  it('reads live overrides from a getter', () => {
+    let speechPeak = 0.8
+    const normalizer = createVolumeNormalizer(CALIBRATION, () => ({
+      amplitude: { speechPeak },
+      envelope: { riseTimeMs: 0, fallTimeMs: 0 },
+    }))
+
+    const quieter = normalizer.sample(0.4, 0)
+    normalizer.reset()
+    speechPeak = 0.4
+    const louder = normalizer.sample(0.4, 0)
 
     expect(louder.normalized).toBeGreaterThan(quieter.normalized)
+  })
+
+  it('generates calibration anchors and distribution diagnostics from guided samples', () => {
+    const fit = fitVolumeCalibration({
+      silence: [0.001, 0.002, 0.003],
+      quiet: [0.05, 0.06, 0.07],
+      normal: [0.18, 0.2, 0.22],
+      energetic: [0.5, 0.7, 0.9],
+    })
+
+    expect(fit.calibration.amplitude.silenceFloor).toBeGreaterThan(0.002)
+    expect(fit.metrics.silenceP99).toBe(0)
+    expect(fit.metrics.normalMedian).toBeCloseTo(0.5)
+    expect(fit.metrics.speechP99).toBeGreaterThan(0.9)
+    expect(fit.calibration.envelope).toEqual({ riseTimeMs: 100, fallTimeMs: 250 })
+  })
+
+  it('rejects incomplete guided captures instead of inventing missing anchors', () => {
+    expect(() =>
+      fitVolumeCalibration({
+        silence: [0.001],
+        quiet: [],
+        normal: [0.2],
+        energetic: [0.8],
+      }),
+    ).toThrow('at least one quiet sample')
   })
 })

--- a/src/adapters/audio-level.test.ts
+++ b/src/adapters/audio-level.test.ts
@@ -64,7 +64,7 @@ describe('volume calibration', () => {
     expect(fit.metrics.silenceP99).toBe(0)
     expect(fit.metrics.normalMedian).toBeCloseTo(0.5)
     expect(fit.metrics.speechP99).toBeGreaterThan(0.9)
-    expect(fit.calibration.envelope).toEqual({ riseTimeMs: 100, fallTimeMs: 250 })
+    expect(fit.calibration.envelope).toEqual({ riseTimeMs: 100, fallTimeMs: 400 })
   })
 
   it('rejects incomplete guided captures instead of inventing missing anchors', () => {

--- a/src/adapters/audio-level.ts
+++ b/src/adapters/audio-level.ts
@@ -82,7 +82,7 @@ export const DEFAULT_VOLUME_CALIBRATION: VolumeCalibration = {
   },
   envelope: {
     riseTimeMs: 100,
-    fallTimeMs: 250,
+    fallTimeMs: 400,
   },
 }
 
@@ -253,7 +253,7 @@ export function fitVolumeCalibration(
     amplitude,
     envelope: {
       riseTimeMs: Math.max(0, finiteOr(envelope.riseTimeMs, 100)),
-      fallTimeMs: Math.max(0, finiteOr(envelope.fallTimeMs, 250)),
+      fallTimeMs: Math.max(0, finiteOr(envelope.fallTimeMs, 400)),
     },
   }
   const allSpeech = [...capture.quiet, ...capture.normal, ...capture.energetic]

--- a/src/adapters/audio-level.ts
+++ b/src/adapters/audio-level.ts
@@ -1,27 +1,68 @@
-export interface OutputVolumeCalibration {
-  /** Raw RMS values at or below this level are treated as silence. */
-  noiseFloor: number
-  /** Multiplier applied after the noise floor. */
-  gain: number
-  /** Power curve applied after gain. Values below 1 lift quieter speech. */
-  exponent: number
-  /** EMA rate used while the volume is rising. */
-  attack: number
-  /** EMA rate used while the volume is falling. */
-  release: number
+export interface VolumeAmplitudeCalibration {
+  /** Raw values at or below this level are treated as silence. */
+  silenceFloor: number
+  /** Raw value representing ordinary conversational speech. Maps to 0.5. */
+  speechReference: number
+  /** Raw value representing a strong, uncommon speech peak. Maps to 1. */
+  speechPeak: number
 }
 
-export type OutputVolumeCalibrationSource =
-  | Partial<OutputVolumeCalibration>
-  | (() => Partial<OutputVolumeCalibration>)
+export interface VolumeEnvelopeCalibration {
+  /** Milliseconds to move 90% toward a rising target. */
+  riseTimeMs: number
+  /** Milliseconds to move 90% toward a falling target. */
+  fallTimeMs: number
+}
 
-export interface OutputVolumeSample {
-  /** Unmodified RMS value measured from the provider audio stream. */
+export interface VolumeCalibration {
+  amplitude: VolumeAmplitudeCalibration
+  envelope: VolumeEnvelopeCalibration
+}
+
+export interface VolumeCalibrationOverrides {
+  amplitude?: Partial<VolumeAmplitudeCalibration>
+  envelope?: Partial<VolumeEnvelopeCalibration>
+}
+
+export type VolumeCalibrationSource =
+  | VolumeCalibrationOverrides
+  | (() => VolumeCalibrationOverrides)
+
+export interface VolumeSample {
+  /** Unmodified value measured from the provider audio source. */
   raw: number
-  /** Value after noise floor, gain, and power-curve shaping. */
-  shaped: number
-  /** Final value after attack/release smoothing. */
+  /** Value after silence, reference, and peak mapping. */
+  mapped: number
+  /** Stable envelope after elapsed-time rise/fall processing. */
   normalized: number
+  /** Elapsed time used for this envelope update. */
+  elapsedMs: number
+}
+
+export interface VolumeCalibrationCapture {
+  silence: number[]
+  quiet: number[]
+  normal: number[]
+  energetic: number[]
+}
+
+export interface VolumeCalibrationMetrics {
+  silenceP99: number
+  quietMedian: number
+  normalMedian: number
+  energeticMedian: number
+  speechP99: number
+  saturationRatio: number
+}
+
+export interface VolumeCalibrationFit {
+  calibration: VolumeCalibration
+  metrics: VolumeCalibrationMetrics
+}
+
+export interface VolumeNormalizer {
+  sample(rawValue: number, timestampMs?: number): VolumeSample
+  reset(value?: number): void
 }
 
 export interface MediaStreamTrackVolumeMeter {
@@ -30,12 +71,19 @@ export interface MediaStreamTrackVolumeMeter {
 
 export type AudioContextSource = () => AudioContext | undefined
 
-export const DEFAULT_OUTPUT_VOLUME_CALIBRATION: OutputVolumeCalibration = {
-  noiseFloor: 0,
-  gain: 4,
-  exponent: 0.8,
-  attack: 1,
-  release: 1,
+const MIN_AMPLITUDE_GAP = 0.000_001
+const DEFAULT_SAMPLE_INTERVAL_MS = 1000 / 30
+
+export const DEFAULT_VOLUME_CALIBRATION: VolumeCalibration = {
+  amplitude: {
+    silenceFloor: 0,
+    speechReference: 0.5,
+    speechPeak: 1,
+  },
+  envelope: {
+    riseTimeMs: 100,
+    fallTimeMs: 250,
+  },
 }
 
 function clamp(value: number, min: number, max: number) {
@@ -46,40 +94,185 @@ function finiteOr(value: number | undefined, fallback: number) {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback
 }
 
+function resolveAmplitudeCalibration(
+  defaults: VolumeAmplitudeCalibration,
+  overrides?: Partial<VolumeAmplitudeCalibration>,
+): VolumeAmplitudeCalibration {
+  const silenceFloor = clamp(
+    finiteOr(overrides?.silenceFloor, defaults.silenceFloor),
+    0,
+    1 - MIN_AMPLITUDE_GAP * 2,
+  )
+  const speechReference = clamp(
+    finiteOr(overrides?.speechReference, defaults.speechReference),
+    silenceFloor + MIN_AMPLITUDE_GAP,
+    1 - MIN_AMPLITUDE_GAP,
+  )
+  const speechPeak = clamp(
+    finiteOr(overrides?.speechPeak, defaults.speechPeak),
+    speechReference + MIN_AMPLITUDE_GAP,
+    1,
+  )
+
+  return { silenceFloor, speechReference, speechPeak }
+}
+
 function resolveCalibration(
-  source: OutputVolumeCalibrationSource | undefined,
-): OutputVolumeCalibration {
+  defaults: VolumeCalibration,
+  source: VolumeCalibrationSource | undefined,
+): VolumeCalibration {
   const overrides = typeof source === 'function' ? source() : source
 
   return {
-    noiseFloor: clamp(
-      finiteOr(overrides?.noiseFloor, DEFAULT_OUTPUT_VOLUME_CALIBRATION.noiseFloor),
-      0,
-      1,
-    ),
-    gain: Math.max(0, finiteOr(overrides?.gain, DEFAULT_OUTPUT_VOLUME_CALIBRATION.gain)),
-    exponent: Math.max(
-      0.01,
-      finiteOr(overrides?.exponent, DEFAULT_OUTPUT_VOLUME_CALIBRATION.exponent),
-    ),
-    attack: clamp(finiteOr(overrides?.attack, DEFAULT_OUTPUT_VOLUME_CALIBRATION.attack), 0, 1),
-    release: clamp(finiteOr(overrides?.release, DEFAULT_OUTPUT_VOLUME_CALIBRATION.release), 0, 1),
+    amplitude: resolveAmplitudeCalibration(defaults.amplitude, overrides?.amplitude),
+    envelope: {
+      riseTimeMs: Math.max(
+        0,
+        finiteOr(overrides?.envelope?.riseTimeMs, defaults.envelope.riseTimeMs),
+      ),
+      fallTimeMs: Math.max(
+        0,
+        finiteOr(overrides?.envelope?.fallTimeMs, defaults.envelope.fallTimeMs),
+      ),
+    },
   }
 }
 
-export function calibrateOutputVolume(
+export function mapVolumeAmplitude(rawValue: number, calibration: VolumeAmplitudeCalibration) {
+  const resolved = resolveAmplitudeCalibration(DEFAULT_VOLUME_CALIBRATION.amplitude, calibration)
+  const raw = Number.isFinite(rawValue) ? clamp(rawValue, 0, 1) : 0
+  if (raw <= resolved.silenceFloor) return 0
+  if (raw >= resolved.speechPeak) return 1
+
+  const range = resolved.speechPeak - resolved.silenceFloor
+  const scaled = clamp((raw - resolved.silenceFloor) / range, 0, 1)
+  const referencePosition = clamp(
+    (resolved.speechReference - resolved.silenceFloor) / range,
+    MIN_AMPLITUDE_GAP,
+    1 - MIN_AMPLITUDE_GAP,
+  )
+  const exponent = Math.log(0.5) / Math.log(referencePosition)
+  return clamp(Math.pow(scaled, exponent), 0, 1)
+}
+
+function followEnvelope(current: number, target: number, durationMs: number, elapsedMs: number) {
+  if (durationMs <= 0) return target
+  const rate = 1 - Math.pow(0.1, Math.max(0, elapsedMs) / durationMs)
+  return clamp(current + (target - current) * rate, 0, 1)
+}
+
+export function calibrateVolume(
   rawValue: number,
   previous: number,
-  source?: OutputVolumeCalibrationSource,
-): OutputVolumeSample {
+  elapsedMs: number,
+  defaults: VolumeCalibration = DEFAULT_VOLUME_CALIBRATION,
+  source?: VolumeCalibrationSource,
+): VolumeSample {
+  const calibration = resolveCalibration(defaults, source)
   const raw = Number.isFinite(rawValue) ? clamp(rawValue, 0, 1) : 0
-  const calibration = resolveCalibration(source)
-  const gated = raw <= calibration.noiseFloor ? 0 : raw - calibration.noiseFloor
-  const shaped = Math.pow(clamp(gated * calibration.gain, 0, 1), calibration.exponent)
-  const rate = shaped > previous ? calibration.attack : calibration.release
-  const normalized = clamp(previous + (shaped - previous) * rate, 0, 1)
+  const mapped = mapVolumeAmplitude(raw, calibration.amplitude)
+  const durationMs =
+    mapped > previous ? calibration.envelope.riseTimeMs : calibration.envelope.fallTimeMs
+  const normalized = followEnvelope(previous, mapped, durationMs, elapsedMs)
 
-  return { raw, shaped, normalized }
+  return { raw, mapped, normalized, elapsedMs }
+}
+
+export function createVolumeNormalizer(
+  defaults: VolumeCalibration = DEFAULT_VOLUME_CALIBRATION,
+  source?: VolumeCalibrationSource,
+): VolumeNormalizer {
+  let current = 0
+  let lastTimestamp: number | undefined
+
+  return {
+    sample(rawValue, timestampMs = performance.now()) {
+      const elapsedMs =
+        lastTimestamp === undefined
+          ? DEFAULT_SAMPLE_INTERVAL_MS
+          : clamp(timestampMs - lastTimestamp, 0, 1000)
+      lastTimestamp = timestampMs
+      const sample = calibrateVolume(rawValue, current, elapsedMs, defaults, source)
+      current = sample.normalized
+      return sample
+    },
+    reset(value = 0) {
+      current = clamp(value, 0, 1)
+      lastTimestamp = undefined
+    },
+  }
+}
+
+function percentile(values: number[], position: number) {
+  const sorted = values
+    .filter((value) => Number.isFinite(value))
+    .map((value) => clamp(value, 0, 1))
+    .sort((a, b) => a - b)
+  if (sorted.length === 0) return 0
+  const index = clamp(position, 0, 1) * (sorted.length - 1)
+  const lower = Math.floor(index)
+  const upper = Math.ceil(index)
+  const mix = index - lower
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * mix
+}
+
+function mappedPercentile(
+  values: number[],
+  position: number,
+  calibration: VolumeAmplitudeCalibration,
+) {
+  return percentile(
+    values.map((value) => mapVolumeAmplitude(value, calibration)),
+    position,
+  )
+}
+
+export function fitVolumeCalibration(
+  capture: VolumeCalibrationCapture,
+  envelope: VolumeEnvelopeCalibration = DEFAULT_VOLUME_CALIBRATION.envelope,
+): VolumeCalibrationFit {
+  for (const phase of ['silence', 'quiet', 'normal', 'energetic'] as const) {
+    if (!capture[phase].some((value) => Number.isFinite(value))) {
+      throw new Error(`Volume calibration requires at least one ${phase} sample.`)
+    }
+  }
+
+  const silenceP99Raw = percentile(capture.silence, 0.99)
+  const normalMedianRaw = percentile(capture.normal, 0.5)
+  const energeticPeakRaw = Math.max(
+    percentile(capture.energetic, 0.99),
+    percentile(capture.normal, 0.99),
+  )
+  const availableRange = Math.max(0, normalMedianRaw - silenceP99Raw)
+  const amplitude = resolveAmplitudeCalibration(DEFAULT_VOLUME_CALIBRATION.amplitude, {
+    silenceFloor: silenceP99Raw + Math.min(0.005, availableRange * 0.05),
+    speechReference: normalMedianRaw,
+    speechPeak: energeticPeakRaw,
+  })
+  const calibration: VolumeCalibration = {
+    amplitude,
+    envelope: {
+      riseTimeMs: Math.max(0, finiteOr(envelope.riseTimeMs, 100)),
+      fallTimeMs: Math.max(0, finiteOr(envelope.fallTimeMs, 250)),
+    },
+  }
+  const allSpeech = [...capture.quiet, ...capture.normal, ...capture.energetic]
+  const mappedSpeech = allSpeech.map((value) => mapVolumeAmplitude(value, calibration.amplitude))
+
+  return {
+    calibration,
+    metrics: {
+      silenceP99: mappedPercentile(capture.silence, 0.99, calibration.amplitude),
+      quietMedian: mappedPercentile(capture.quiet, 0.5, calibration.amplitude),
+      normalMedian: mappedPercentile(capture.normal, 0.5, calibration.amplitude),
+      energeticMedian: mappedPercentile(capture.energetic, 0.5, calibration.amplitude),
+      speechP99: percentile(mappedSpeech, 0.99),
+      saturationRatio:
+        mappedSpeech.length === 0
+          ? 0
+          : mappedSpeech.filter((value) => value >= 0.999).length / mappedSpeech.length,
+    },
+  }
 }
 
 export function createMediaStreamTrackVolumeMeter(

--- a/src/adapters/elevenlabs/index.ts
+++ b/src/adapters/elevenlabs/index.ts
@@ -161,9 +161,17 @@ export function createElevenLabsAdapter(
 
   function setState(state: OrbState) {
     currentState = state
-    inputNormalizer.reset()
-    outputNormalizer.reset()
-    emitPatch({ state, inputVolume: 0, outputVolume: 0 })
+    if (state === 'idle' || state === 'connecting' || state === 'error') {
+      inputNormalizer.reset()
+      outputNormalizer.reset()
+      emitPatch({ state, inputVolume: 0, outputVolume: 0 })
+      return
+    }
+
+    // Listening/speaking are views over two continuous directional envelopes.
+    // Preserve both across mode changes so the newly active direction does not
+    // spend a frame at an artificial zero.
+    emitPatch({ state })
   }
 
   function startVolumePolling() {
@@ -175,11 +183,10 @@ export function createElevenLabsAdapter(
       onInputVolumeSample?.(inputSample)
       onOutputVolumeSample?.(outputSample)
 
-      if (currentState === 'listening') {
-        emitPatch({ inputVolume: inputSample.normalized, outputVolume: 0 })
-      } else if (currentState === 'speaking') {
-        emitPatch({ inputVolume: 0, outputVolume: outputSample.normalized })
-      }
+      emitPatch({
+        inputVolume: inputSample.normalized,
+        outputVolume: outputSample.normalized,
+      })
     }, 33) // ~30 fps
   }
 

--- a/src/adapters/elevenlabs/index.ts
+++ b/src/adapters/elevenlabs/index.ts
@@ -1,4 +1,7 @@
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
+import { createVolumeNormalizer } from '../audio-level'
+import type { VolumeCalibrationSource, VolumeSample } from '../audio-level'
+import { PROVIDER_VOLUME_CALIBRATIONS } from '../volume-presets'
 
 // ─── ElevenLabs type interfaces ───────────────────────────────────────────────
 // We define minimal interfaces rather than importing @elevenlabs/client directly
@@ -45,14 +48,25 @@ type ElevenLabsSessionAuth =
       connectionType?: 'webrtc'
     }
 
-export type ElevenLabsConfig = ElevenLabsSessionAuth & {
+type ElevenLabsSessionConfig = ElevenLabsSessionAuth & {
   /** orb-ui expects a voice conversation, so text-only sessions are intentionally unsupported. */
   textOnly?: false
   /** Allow @elevenlabs/client startSession options that orb-ui does not inspect. */
   [key: string]: unknown
 }
 
-export type ElevenLabsStartSessionOptions = ElevenLabsConfig & ElevenLabsCallbacks
+export type ElevenLabsConfig = ElevenLabsSessionConfig & {
+  /** Optional live-tunable input calibration overrides. */
+  inputVolumeCalibration?: VolumeCalibrationSource
+  /** Optional live-tunable output calibration overrides. */
+  outputVolumeCalibration?: VolumeCalibrationSource
+  /** Receives raw, mapped, and normalized input levels for diagnostics. */
+  onInputVolumeSample?: (sample: VolumeSample) => void
+  /** Receives raw, mapped, and normalized output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: VolumeSample) => void
+}
+
+export type ElevenLabsStartSessionOptions = ElevenLabsSessionConfig & ElevenLabsCallbacks
 
 // The Conversation namespace from @elevenlabs/client (minimal structural interface).
 export interface ElevenLabsConversationClass {
@@ -73,21 +87,12 @@ export interface ElevenLabsOrbAdapter extends OrbAdapter {
 
 // ─── ElevenLabs signal normalization ─────────────────────────────────────────
 //
-// ElevenLabs provides two clean, continuous audio signals — no quantization
-// artifacts like Vapi. However both signals need gain + smoothing to match
-// Vapi's normalized output range.
-//
-// Empirical measurements (2026-03-02, live call):
-//   Raw PEAK = 0.64, AVG = 0.49 with OUTPUT_GAIN=1.8 → target PEAK ~0.95
-//   → New OUTPUT_GAIN = 1.8 × (0.95 / 0.64) = 2.7
+// ElevenLabs provides two clean, continuous audio signals. Directional
+// calibration maps both sources into the same semantic 0–1 envelope.
 //
 // Volume sources:
 //   • getInputVolume()          — Web Audio RMS of user input, polled ~30fps.
 //   • getOutputVolume()         — Web Audio RMS of AI output, polled ~30fps.
-//     Apply gain to make visual movement readable across providers.
-//
-// EMA config: lighter than Vapi (EL signal is already clean, less smoothing needed)
-//   attack=0.5 (fast rise), release=0.15 (moderate decay)
 
 /**
  * Creates an OrbAdapter for ElevenLabs Conversational AI.
@@ -117,13 +122,28 @@ export function createElevenLabsAdapter(
   ConversationClass: ElevenLabsConversationClass,
   config: ElevenLabsConfig,
 ): ElevenLabsOrbAdapter {
+  const {
+    inputVolumeCalibration,
+    outputVolumeCalibration,
+    onInputVolumeSample,
+    onOutputVolumeSample,
+    ...sessionConfig
+  } = config
   // Active conversation instance + cleanup reference
   let conversation: ElevenLabsConversation | null = null
   let activeSessionId = 0
   let startPromise: Promise<void> | null = null
   let volumeInterval: ReturnType<typeof setInterval> | null = null
-  let signal: OrbSignal = { state: 'idle', volume: 0, inputVolume: 0, outputVolume: 0 }
+  let signal: OrbSignal = { state: 'idle', inputVolume: 0, outputVolume: 0 }
   let currentState: OrbState = 'idle'
+  const inputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.elevenlabs.input,
+    inputVolumeCalibration,
+  )
+  const outputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.elevenlabs.output,
+    outputVolumeCalibration,
+  )
 
   // Subscriber registry — supports multiple simultaneous subscribers
   // (e.g. Orb + signal monitor both subscribing at the same time)
@@ -141,19 +161,24 @@ export function createElevenLabsAdapter(
 
   function setState(state: OrbState) {
     currentState = state
-    emitPatch({ state })
+    inputNormalizer.reset()
+    outputNormalizer.reset()
+    emitPatch({ state, inputVolume: 0, outputVolume: 0 })
   }
 
   function startVolumePolling() {
     if (volumeInterval) return
     volumeInterval = setInterval(() => {
       if (!conversation) return
+      const inputSample = inputNormalizer.sample(conversation.getInputVolume())
+      const outputSample = outputNormalizer.sample(conversation.getOutputVolume())
+      onInputVolumeSample?.(inputSample)
+      onOutputVolumeSample?.(outputSample)
+
       if (currentState === 'listening') {
-        const inputVolume = Math.min(conversation.getInputVolume() * 2.0, 1.0)
-        emitPatch({ volume: inputVolume, inputVolume })
+        emitPatch({ inputVolume: inputSample.normalized, outputVolume: 0 })
       } else if (currentState === 'speaking') {
-        const outputVolume = Math.min(conversation.getOutputVolume() * 2.0, 1.0)
-        emitPatch({ volume: outputVolume, outputVolume })
+        emitPatch({ inputVolume: 0, outputVolume: outputSample.normalized })
       }
     }, 33) // ~30 fps
   }
@@ -167,12 +192,16 @@ export function createElevenLabsAdapter(
 
   function stopVolumePolling() {
     clearVolumePolling()
-    emitPatch({ volume: 0, inputVolume: 0, outputVolume: 0 })
+    inputNormalizer.reset()
+    outputNormalizer.reset()
+    emitPatch({ inputVolume: 0, outputVolume: 0 })
   }
 
   function emitIdleSignal() {
     currentState = 'idle'
-    emitPatch({ state: 'idle', volume: 0, inputVolume: 0, outputVolume: 0 })
+    inputNormalizer.reset()
+    outputNormalizer.reset()
+    emitPatch({ state: 'idle', inputVolume: 0, outputVolume: 0 })
   }
 
   function isActiveSession(sessionId: number) {
@@ -215,7 +244,7 @@ export function createElevenLabsAdapter(
         console.error('[orb-ui/elevenlabs] Error:', message)
         clearVolumePolling()
         currentState = 'error'
-        emitPatch({ state: 'error', volume: 0, inputVolume: 0, outputVolume: 0, error: message })
+        emitPatch({ state: 'error', inputVolume: 0, outputVolume: 0, error: message })
         conversation = null
       },
     }
@@ -243,7 +272,7 @@ export function createElevenLabsAdapter(
       startPromise = (async () => {
         try {
           const nextConversation = await ConversationClass.startSession({
-            ...config,
+            ...sessionConfig,
             ...createElevenLabsCallbacks(sessionId),
           })
           if (!isActiveSession(sessionId)) {
@@ -257,7 +286,7 @@ export function createElevenLabsAdapter(
           if (!isActiveSession(sessionId)) return
           console.error('[orb-ui/elevenlabs] startSession failed:', err)
           setState('error')
-          emitPatch({ volume: 0, inputVolume: 0, outputVolume: 0, error: err })
+          emitPatch({ inputVolume: 0, outputVolume: 0, error: err })
         } finally {
           startPromise = null
         }

--- a/src/adapters/elevenlabs/index.ts
+++ b/src/adapters/elevenlabs/index.ts
@@ -22,8 +22,8 @@ export interface ElevenLabsCallbacks {
 
 export interface ElevenLabsConversation {
   endSession(): Promise<void>
-  getInputVolume(): number // normalized RMS of mic input (0–1)
-  getOutputVolume(): number // normalized RMS of AI audio output (0–1)
+  getInputVolume(): number // SDK voice-band frequency level of mic input (0–1)
+  getOutputVolume(): number // SDK voice-band frequency level of AI output (0–1)
   getInputByteFrequencyData(): Uint8Array
   getOutputByteFrequencyData(): Uint8Array
 }
@@ -91,8 +91,9 @@ export interface ElevenLabsOrbAdapter extends OrbAdapter {
 // calibration maps both sources into the same semantic 0–1 envelope.
 //
 // Volume sources:
-//   • getInputVolume()          — Web Audio RMS of user input, polled ~30fps.
-//   • getOutputVolume()         — Web Audio RMS of AI output, polled ~30fps.
+//   • getInputVolume()          — SDK frequency-based input level, polled ~30fps.
+//   • getOutputVolume()         — SDK frequency-based output level, polled ~30fps.
+// These are not waveform RMS values; calibrate the SDK measurement directly.
 
 /**
  * Creates an OrbAdapter for ElevenLabs Conversational AI.

--- a/src/adapters/gemini-live/index.test.ts
+++ b/src/adapters/gemini-live/index.test.ts
@@ -90,7 +90,12 @@ describe('createGeminiLiveAdapter', () => {
     const context = new FakeAudioContext()
     context.outputSample = 0.01
     let callbacks: GeminiLiveCallbacks | undefined
-    const outputSamples: Array<{ raw: number; shaped: number; normalized: number }> = []
+    const outputSamples: Array<{
+      raw: number
+      mapped: number
+      normalized: number
+      elapsedMs: number
+    }> = []
     const sent: Array<Parameters<GeminiLiveSession['sendRealtimeInput']>[0]> = []
     const session: GeminiLiveSession = {
       sendRealtimeInput: vi.fn((input) => sent.push(input)),
@@ -132,10 +137,9 @@ describe('createGeminiLiveAdapter', () => {
     expect(signals.at(-1)).toMatchObject({ state: 'speaking' })
     expect(context.sources).toHaveLength(1)
     vi.advanceTimersByTime(33)
-    const expectedShaped = Math.pow((0.01 - 0.003) * 4, 0.8)
     expect(outputSamples.at(-1)?.raw).toBeCloseTo(0.01)
-    expect(outputSamples.at(-1)?.shaped).toBeCloseTo(expectedShaped)
-    expect(outputSamples.at(-1)?.normalized).toBeCloseTo(expectedShaped * 0.3)
+    expect(outputSamples.at(-1)?.mapped).toBeGreaterThan(0)
+    expect(outputSamples.at(-1)?.normalized).toBeGreaterThan(0)
 
     const speakingSignalCount = signals.length
     callbacks?.onmessage({

--- a/src/adapters/gemini-live/index.test.ts
+++ b/src/adapters/gemini-live/index.test.ts
@@ -191,9 +191,34 @@ describe('createGeminiLiveAdapter', () => {
         },
       },
     })
+    context.processor.process(new Float32Array(4096).fill(0.2))
+    expect(signals.at(-1)).toMatchObject({ state: 'listening' })
+    const interruptedSignalCount = signals.length
+    callbacks?.onmessage({
+      serverContent: {
+        modelTurn: {
+          parts: [{ inlineData: { data: btoa(String.fromCharCode(0, 0)) } }],
+        },
+      },
+    })
+    expect(context.sources).toHaveLength(2)
+    expect(signals).toHaveLength(interruptedSignalCount)
+    expect(signals.at(-1)).toMatchObject({ state: 'listening' })
     callbacks?.onmessage({ serverContent: { interrupted: true } })
     expect(context.sources[0].stop).toHaveBeenCalled()
+    expect(context.sources[1].stop).toHaveBeenCalled()
     expect(signals.at(-1)).toMatchObject({ state: 'listening' })
+
+    context.processor.process(new Float32Array(4096))
+    vi.advanceTimersByTime(500)
+    callbacks?.onmessage({
+      serverContent: {
+        modelTurn: {
+          parts: [{ inlineData: { data: btoa(String.fromCharCode(0, 0)) } }],
+        },
+      },
+    })
+    expect(signals.at(-1)).toMatchObject({ state: 'speaking' })
 
     const error = new Error('socket failed')
     callbacks?.onerror?.(error)

--- a/src/adapters/gemini-live/index.ts
+++ b/src/adapters/gemini-live/index.ts
@@ -167,12 +167,15 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
 
   function emitState(state: OrbState, error?: unknown) {
     if (signal.state === state && error === undefined) return
-    inputNormalizer.reset()
-    outputNormalizer.reset()
+    const resetsEnvelope = state === 'idle' || state === 'connecting' || state === 'error'
+    if (resetsEnvelope) {
+      inputNormalizer.reset()
+      outputNormalizer.reset()
+    }
     emit({
+      ...signal,
       state,
-      inputVolume: 0,
-      outputVolume: 0,
+      ...(resetsEnvelope ? { inputVolume: 0, outputVolume: 0 } : {}),
       ...(error === undefined ? {} : { error }),
     })
   }
@@ -208,9 +211,7 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
       }, config.speechEndDelayMs ?? 500)
     }
 
-    if (signal.state === 'listening') {
-      emit({ ...signal, inputVolume, outputVolume: 0 })
-    }
+    emit({ ...signal, inputVolume })
   }
 
   function stopScheduledAudio() {
@@ -293,9 +294,7 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
       outputAnalyser.getFloatTimeDomainData(samples)
       const sample = outputNormalizer.sample(calculateRms(samples))
       config.onOutputVolumeSample?.(sample)
-      if (signal.state === 'speaking') {
-        emit({ ...signal, inputVolume: 0, outputVolume: sample.normalized })
-      }
+      emit({ ...signal, outputVolume: sample.normalized })
     }, 33)
   }
 

--- a/src/adapters/gemini-live/index.ts
+++ b/src/adapters/gemini-live/index.ts
@@ -1,10 +1,7 @@
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
-import { calibrateOutputVolume } from '../audio-level'
-import type {
-  OutputVolumeCalibration,
-  OutputVolumeCalibrationSource,
-  OutputVolumeSample,
-} from '../audio-level'
+import { createVolumeNormalizer } from '../audio-level'
+import type { VolumeCalibrationSource, VolumeSample } from '../audio-level'
+import { PROVIDER_VOLUME_CALIBRATIONS } from '../volume-presets'
 
 export interface GeminiLiveInlineData {
   data?: string
@@ -58,10 +55,14 @@ export interface GeminiLiveAdapterConfig {
   getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>
   /** Runtime override for tests or custom browser wrappers. */
   createAudioContext?: () => AudioContext
-  /** Optional live-tunable output shaping. A getter is read for every meter sample. */
-  outputVolumeCalibration?: OutputVolumeCalibrationSource
-  /** Receives raw, shaped, and smoothed output levels for diagnostics. */
-  onOutputVolumeSample?: (sample: OutputVolumeSample) => void
+  /** Optional live-tunable input calibration overrides. */
+  inputVolumeCalibration?: VolumeCalibrationSource
+  /** Optional live-tunable output calibration overrides. */
+  outputVolumeCalibration?: VolumeCalibrationSource
+  /** Receives raw, mapped, and normalized input levels for diagnostics. */
+  onInputVolumeSample?: (sample: VolumeSample) => void
+  /** Receives raw, mapped, and normalized output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: VolumeSample) => void
 }
 
 export interface GeminiLiveOrbAdapter extends OrbAdapter {
@@ -70,22 +71,10 @@ export interface GeminiLiveOrbAdapter extends OrbAdapter {
 }
 
 const DEFAULT_INPUT_SAMPLE_RATE = 16_000
-const DEFAULT_GEMINI_OUTPUT_CALIBRATION: OutputVolumeCalibration = {
-  noiseFloor: 0.003,
-  gain: 4,
-  exponent: 0.8,
-  attack: 0.3,
-  release: 0.1,
-}
-
 function calculateRms(samples: Float32Array) {
   let sumSquares = 0
   for (const sample of samples) sumSquares += sample * sample
   return Math.sqrt(sumSquares / samples.length)
-}
-
-function normalizeInputRms(samples: Float32Array) {
-  return Math.min(1, Math.max(0, Math.pow(calculateRms(samples) * 4, 0.8)))
 }
 
 function resample(samples: Float32Array, sourceRate: number, targetRate: number) {
@@ -144,7 +133,7 @@ function sampleRateFromMimeType(mimeType: string | undefined) {
 export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): GeminiLiveOrbAdapter {
   const listeners = new Set<OrbSignalListener>()
   const scheduledSources = new Set<AudioBufferSourceNode>()
-  let signal: OrbSignal = { state: 'idle', volume: 0, inputVolume: 0, outputVolume: 0 }
+  let signal: OrbSignal = { state: 'idle', inputVolume: 0, outputVolume: 0 }
   let session: GeminiLiveSession | null = null
   let stream: MediaStream | null = null
   let audioContext: AudioContext | null = null
@@ -156,20 +145,19 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
   let speechEndTimer: ReturnType<typeof setTimeout> | null = null
   let userSpeaking = false
   let nextOutputTime = 0
-  let outputVolumeLevel = 0
   let turnComplete = false
   let stopping = false
+  const inputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.gemini.input,
+    config.inputVolumeCalibration,
+  )
+  const outputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.gemini.output,
+    config.outputVolumeCalibration,
+  )
 
   function usesClientActivityDetection() {
     return config.activityDetection !== 'server'
-  }
-
-  function getOutputVolumeCalibration() {
-    const overrides =
-      typeof config.outputVolumeCalibration === 'function'
-        ? config.outputVolumeCalibration()
-        : config.outputVolumeCalibration
-    return { ...DEFAULT_GEMINI_OUTPUT_CALIBRATION, ...overrides }
   }
 
   function emit(next: OrbSignal) {
@@ -179,10 +167,10 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
 
   function emitState(state: OrbState, error?: unknown) {
     if (signal.state === state && error === undefined) return
-    if (state !== 'speaking') outputVolumeLevel = 0
+    inputNormalizer.reset()
+    outputNormalizer.reset()
     emit({
       state,
-      volume: 0,
       inputVolume: 0,
       outputVolume: 0,
       ...(error === undefined ? {} : { error }),
@@ -195,9 +183,14 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
     speechEndTimer = null
   }
 
-  function handleInputVolume(inputVolume: number) {
+  function handleInputVolume(rawInputVolume: number) {
+    const sample = inputNormalizer.sample(rawInputVolume)
+    config.onInputVolumeSample?.(sample)
+    const inputVolume = sample.normalized
     const threshold = config.speechThreshold ?? 0.04
-    if (inputVolume > threshold) {
+    // Turn detection should react to the current sample, not wait for the visual
+    // envelope to decay after speech ends.
+    if (sample.mapped > threshold) {
       if (!userSpeaking && usesClientActivityDetection()) {
         session?.sendRealtimeInput({ activityStart: {} })
       }
@@ -216,7 +209,7 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
     }
 
     if (signal.state === 'listening') {
-      emit({ ...signal, volume: inputVolume, inputVolume, outputVolume: 0 })
+      emit({ ...signal, inputVolume, outputVolume: 0 })
     }
   }
 
@@ -296,17 +289,13 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
     if (!outputAnalyser) return
     const samples = new Float32Array(outputAnalyser.fftSize)
     outputVolumeInterval = setInterval(() => {
-      if (!outputAnalyser || signal.state !== 'speaking') return
+      if (!outputAnalyser) return
       outputAnalyser.getFloatTimeDomainData(samples)
-      const sample = calibrateOutputVolume(
-        calculateRms(samples),
-        outputVolumeLevel,
-        getOutputVolumeCalibration,
-      )
-      outputVolumeLevel = sample.normalized
+      const sample = outputNormalizer.sample(calculateRms(samples))
       config.onOutputVolumeSample?.(sample)
-      const outputVolume = sample.normalized
-      emit({ ...signal, volume: outputVolume, inputVolume: 0, outputVolume })
+      if (signal.state === 'speaking') {
+        emit({ ...signal, inputVolume: 0, outputVolume: sample.normalized })
+      }
     }, 33)
   }
 
@@ -322,7 +311,7 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
     inputProcessor.onaudioprocess = (event) => {
       if (!session || stopping) return
       const samples = event.inputBuffer.getChannelData(0)
-      handleInputVolume(normalizeInputRms(samples))
+      handleInputVolume(calculateRms(samples))
       const pcm = resample(
         samples,
         audioContext?.sampleRate ?? DEFAULT_INPUT_SAMPLE_RATE,
@@ -358,7 +347,8 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
     session = null
     userSpeaking = false
     turnComplete = false
-    outputVolumeLevel = 0
+    inputNormalizer.reset()
+    outputNormalizer.reset()
     if (emitIdle) emitState('idle')
     stopping = false
   }

--- a/src/adapters/gemini-live/index.ts
+++ b/src/adapters/gemini-live/index.ts
@@ -255,7 +255,9 @@ export function createGeminiLiveAdapter(config: GeminiLiveAdapterConfig): Gemini
       finishTurnIfReady()
     }
     source.start(startAt)
-    if (signal.state !== 'speaking') emitState('speaking')
+    // Buffered chunks may arrive while the user interrupts. Keep microphone
+    // activity in control until that user turn ends; the server stops playback.
+    if (!userSpeaking && signal.state !== 'speaking') emitState('speaking')
   }
 
   function handleMessage(message: GeminiLiveServerMessage) {

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,4 +1,4 @@
-export { createVapiAdapter } from './vapi'
+export { createVapiAdapter, type VapiAdapterOptions } from './vapi'
 export {
   createElevenLabsAdapter,
   type ElevenLabsCallbacks,
@@ -44,9 +44,21 @@ export {
   type GeminiLiveSession,
 } from './gemini-live'
 export {
-  DEFAULT_OUTPUT_VOLUME_CALIBRATION,
-  type OutputVolumeCalibration,
-  type OutputVolumeCalibrationSource,
-  type OutputVolumeSample,
+  DEFAULT_VOLUME_CALIBRATION,
+  calibrateVolume,
+  createVolumeNormalizer,
+  fitVolumeCalibration,
+  mapVolumeAmplitude,
+  type VolumeAmplitudeCalibration,
+  type VolumeCalibration,
+  type VolumeCalibrationCapture,
+  type VolumeCalibrationFit,
+  type VolumeCalibrationMetrics,
+  type VolumeCalibrationOverrides,
+  type VolumeCalibrationSource,
+  type VolumeEnvelopeCalibration,
+  type VolumeNormalizer,
+  type VolumeSample,
 } from './audio-level'
+export { PROVIDER_VOLUME_CALIBRATIONS, type DirectionalVolumeCalibration } from './volume-presets'
 export type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from './types'

--- a/src/adapters/livekit/browser.test.ts
+++ b/src/adapters/livekit/browser.test.ts
@@ -56,7 +56,7 @@ describe('managed LiveKit browser adapter', () => {
   it('creates sandbox adapters and forwards optional token values', () => {
     const roomName = () => 'custom-room'
     const participantAttributes = () => ({ plan: 'test' })
-    const outputVolumeCalibration = () => ({ gain: 1.25 })
+    const outputVolumeCalibration = () => ({ amplitude: { speechReference: 0.25 } })
     const onOutputVolumeSample = vi.fn()
 
     createLiveKitAdapter({

--- a/src/adapters/livekit/browser.ts
+++ b/src/adapters/livekit/browser.ts
@@ -4,7 +4,7 @@ import {
   type LiveKitOrbAdapter,
   type LiveKitTokenOptions,
 } from './index'
-import type { OutputVolumeCalibrationSource, OutputVolumeSample } from '../audio-level'
+import type { VolumeCalibrationSource, VolumeSample } from '../audio-level'
 
 interface LiveKitBrowserAdapterBase extends Omit<LiveKitTokenOptions, 'agentName' | 'roomName'> {
   /** Agent dispatched into the room. Required for LiveKit Cloud sandbox sessions. */
@@ -15,10 +15,14 @@ interface LiveKitBrowserAdapterBase extends Omit<LiveKitTokenOptions, 'agentName
   connectOptions?: Record<string, unknown>
   /** Enable the local microphone after connecting. Defaults to true. */
   enableMicrophone?: boolean
-  /** Optional live-tunable output shaping. A getter is read for every meter sample. */
-  outputVolumeCalibration?: OutputVolumeCalibrationSource
-  /** Receives raw, shaped, and smoothed output levels for diagnostics. */
-  onOutputVolumeSample?: (sample: OutputVolumeSample) => void
+  /** Optional live-tunable input calibration overrides. */
+  inputVolumeCalibration?: VolumeCalibrationSource
+  /** Optional live-tunable output calibration overrides. */
+  outputVolumeCalibration?: VolumeCalibrationSource
+  /** Receives raw, mapped, and normalized input levels for diagnostics. */
+  onInputVolumeSample?: (sample: VolumeSample) => void
+  /** Receives raw, mapped, and normalized output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: VolumeSample) => void
 }
 
 export type LiveKitTokenEndpointOptions = Omit<RequestInit, 'body'>
@@ -75,7 +79,9 @@ export function createLiveKitAdapter(config: LiveKitBrowserAdapterConfig): LiveK
     participantMetadata,
     participantName,
     roomName = createRoomName,
+    inputVolumeCalibration,
     outputVolumeCalibration,
+    onInputVolumeSample,
     onOutputVolumeSample,
   } = config
 
@@ -98,7 +104,9 @@ export function createLiveKitAdapter(config: LiveKitBrowserAdapterConfig): LiveK
     },
     connectOptions,
     enableMicrophone,
+    inputVolumeCalibration,
     outputVolumeCalibration,
+    onInputVolumeSample,
     onOutputVolumeSample,
     createAudioAnalyser,
     RoomClass: Room,

--- a/src/adapters/livekit/index.test.ts
+++ b/src/adapters/livekit/index.test.ts
@@ -124,8 +124,9 @@ describe('createLiveKitAdapter', () => {
       calculateVolume: vi.fn(() => 0.25),
       cleanup: vi.fn(async () => undefined),
     }
+    let outputRaw = 0
     const outputAnalyser = {
-      calculateVolume: vi.fn(() => 0.5),
+      calculateVolume: vi.fn(() => outputRaw),
       cleanup: vi.fn(async () => undefined),
     }
     const createAudioAnalyser = vi.fn((track: FakeTrack) =>
@@ -144,24 +145,34 @@ describe('createLiveKitAdapter', () => {
     })
     expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
 
+    outputRaw = 0.5
     agent.attributes['lk.agent.state'] = 'speaking'
     room.emit('participantAttributesChanged', { 'lk.agent.state': 'speaking' }, agent)
     vi.advanceTimersByTime(33)
 
     expect(signals.at(-1)).toMatchObject({
       state: 'speaking',
-      inputVolume: 0,
+      inputVolume: expect.any(Number),
       outputVolume: expect.any(Number),
     })
+    expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
     expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
 
+    const speakingOutput = signals.at(-1)?.outputVolume ?? 0
+    outputRaw = 0
     agent.attributes['lk.agent.state'] = 'listening'
     room.emit('participantAttributesChanged', { 'lk.agent.state': 'listening' }, agent)
+    expect(signals.at(-1)).toMatchObject({
+      state: 'listening',
+      outputVolume: speakingOutput,
+    })
     vi.advanceTimersByTime(33)
 
     expect(outputAnalyser.cleanup).not.toHaveBeenCalled()
     expect(signals.at(-1)?.state).toBe('listening')
     expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
+    expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
+    expect(signals.at(-1)?.outputVolume).toBeLessThan(speakingOutput)
 
     room.emit('localTrackUnpublished', { source: 'microphone', track: localTrack })
 
@@ -256,7 +267,8 @@ describe('createLiveKitAdapter', () => {
       new FakeParticipant({ attributes: { 'lk.agent.state': 'thinking' }, kind: 4 }),
     )
 
-    expect(signals.at(-1)).toMatchObject({ state: 'thinking', outputVolume: 0 })
+    expect(signals.at(-1)).toMatchObject({ state: 'thinking' })
+    expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
     expect(analyser.cleanup).not.toHaveBeenCalled()
 
     unsubscribe()

--- a/src/adapters/livekit/index.test.ts
+++ b/src/adapters/livekit/index.test.ts
@@ -159,16 +159,17 @@ describe('createLiveKitAdapter', () => {
     room.emit('participantAttributesChanged', { 'lk.agent.state': 'listening' }, agent)
     vi.advanceTimersByTime(33)
 
-    expect(outputAnalyser.cleanup).toHaveBeenCalledOnce()
+    expect(outputAnalyser.cleanup).not.toHaveBeenCalled()
     expect(signals.at(-1)?.state).toBe('listening')
     expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
 
     room.emit('localTrackUnpublished', { source: 'microphone', track: localTrack })
 
     expect(inputAnalyser.cleanup).toHaveBeenCalledOnce()
-    expect(signals.at(-1)).toMatchObject({ volume: 0, inputVolume: 0 })
+    expect(signals.at(-1)).toMatchObject({ inputVolume: 0 })
 
     unsubscribe()
+    expect(outputAnalyser.cleanup).toHaveBeenCalledOnce()
   })
 
   it('keeps remote speech dynamic instead of flattening analyser output near maximum', () => {
@@ -206,7 +207,7 @@ describe('createLiveKitAdapter', () => {
 
     expect(outputLevels[0]).toBeGreaterThan(0)
     expect(outputLevels[1]).toBeGreaterThan(outputLevels[0])
-    expect(outputLevels[1]).toBeLessThan(0.5)
+    expect(outputLevels[1]).toBeLessThan(1)
     expect(outputLevels[3]).toBeLessThan(outputLevels[1])
     expect(onOutputVolumeSample).toHaveBeenCalledTimes(4)
     expect(onOutputVolumeSample.mock.calls.map(([sample]) => sample.raw)).toEqual([
@@ -255,10 +256,11 @@ describe('createLiveKitAdapter', () => {
       new FakeParticipant({ attributes: { 'lk.agent.state': 'thinking' }, kind: 4 }),
     )
 
-    expect(signals.at(-1)).toMatchObject({ state: 'thinking', volume: 0, outputVolume: 0 })
-    expect(analyser.cleanup).toHaveBeenCalledOnce()
+    expect(signals.at(-1)).toMatchObject({ state: 'thinking', outputVolume: 0 })
+    expect(analyser.cleanup).not.toHaveBeenCalled()
 
     unsubscribe()
+    expect(analyser.cleanup).toHaveBeenCalledOnce()
   })
 
   it('keeps external rooms non-interactive and detaches agent audio on unsubscribe', () => {
@@ -349,7 +351,6 @@ describe('createLiveKitAdapter', () => {
     expect(localAnalyser.cleanup).toHaveBeenCalledOnce()
     expect(signals.at(-1)).toMatchObject({
       state: 'idle',
-      volume: 0,
       inputVolume: 0,
       outputVolume: 0,
     })

--- a/src/adapters/livekit/index.ts
+++ b/src/adapters/livekit/index.ts
@@ -1,11 +1,7 @@
-import { normalizeMicVolume } from '../types'
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
-import { calibrateOutputVolume } from '../audio-level'
-import type {
-  OutputVolumeCalibration,
-  OutputVolumeCalibrationSource,
-  OutputVolumeSample,
-} from '../audio-level'
+import { createVolumeNormalizer } from '../audio-level'
+import type { VolumeCalibrationSource, VolumeSample } from '../audio-level'
+import { PROVIDER_VOLUME_CALIBRATIONS } from '../volume-presets'
 
 // Minimal LiveKit interfaces. orb-ui does not import livekit-client directly so
 // the SDK remains an app-owned dependency.
@@ -101,14 +97,6 @@ const LIVEKIT_ANALYSER_OPTIONS = {
   maxDecibels: -20,
 }
 
-const DEFAULT_LIVEKIT_OUTPUT_CALIBRATION: OutputVolumeCalibration = {
-  noiseFloor: 0.015,
-  gain: 4.6,
-  exponent: 1.15,
-  attack: 0.1,
-  release: 0.48,
-}
-
 function mapAgentState(lkState: string): OrbState {
   switch (lkState) {
     case 'speaking':
@@ -132,10 +120,14 @@ function mapAgentState(lkState: string): OrbState {
 }
 
 interface LiveKitVolumeConfig {
-  /** Optional live-tunable output shaping. A getter is read for every meter sample. */
-  outputVolumeCalibration?: OutputVolumeCalibrationSource
-  /** Receives raw, shaped, and smoothed output levels for diagnostics. */
-  onOutputVolumeSample?: (sample: OutputVolumeSample) => void
+  /** Optional live-tunable input calibration overrides. */
+  inputVolumeCalibration?: VolumeCalibrationSource
+  /** Optional live-tunable output calibration overrides. */
+  outputVolumeCalibration?: VolumeCalibrationSource
+  /** Receives raw, mapped, and normalized input levels for diagnostics. */
+  onInputVolumeSample?: (sample: VolumeSample) => void
+  /** Receives raw, mapped, and normalized output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: VolumeSample) => void
 }
 
 interface LiveKitManagedBaseConfig<TTrack = unknown> extends LiveKitVolumeConfig {
@@ -327,7 +319,7 @@ export function createLiveKitAdapter<TTrack = unknown>(
   }
   const listeners = new Set<OrbSignalListener>()
 
-  let signal: OrbSignal = { state: 'idle', volume: 0, inputVolume: 0, outputVolume: 0 }
+  let signal: OrbSignal = { state: 'idle', inputVolume: 0, outputVolume: 0 }
   let currentState: OrbState = 'idle'
   let localMicrophoneTrack: LKAudioTrack | null = null
   let agentTrack: LKRemoteAudioTrack | null = null
@@ -336,8 +328,15 @@ export function createLiveKitAdapter<TTrack = unknown>(
   let inputVolumeInterval: ReturnType<typeof setInterval> | null = null
   let outputAnalyserResult: LKAnalyserResult | null = null
   let outputVolumeInterval: ReturnType<typeof setInterval> | null = null
-  let outputEmaVolume = 0
   let unsubscribeRoom: (() => void) | null = null
+  const inputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.livekit.input,
+    config.inputVolumeCalibration,
+  )
+  const outputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.livekit.output,
+    config.outputVolumeCalibration,
+  )
 
   function emitSignal(nextSignal: OrbSignal) {
     signal = nextSignal
@@ -348,24 +347,9 @@ export function createLiveKitAdapter<TTrack = unknown>(
     emitSignal({ ...signal, ...patch, state: patch.state ?? signal.state })
   }
 
-  function getOutputVolumeCalibration() {
-    const overrides =
-      typeof config.outputVolumeCalibration === 'function'
-        ? config.outputVolumeCalibration()
-        : config.outputVolumeCalibration
-    return { ...DEFAULT_LIVEKIT_OUTPUT_CALIBRATION, ...overrides }
-  }
-
-  function normalizeVolume(raw: number): number {
-    const sample = calibrateOutputVolume(raw, outputEmaVolume, getOutputVolumeCalibration)
-    outputEmaVolume = sample.normalized
-    config.onOutputVolumeSample?.(sample)
-    return sample.normalized
-  }
-
   function resetOutputVolume() {
-    outputEmaVolume = 0
-    emitPatch({ volume: 0, outputVolume: 0 })
+    outputNormalizer.reset()
+    emitPatch({ outputVolume: 0 })
   }
 
   function stopInputVolumeTracking({ emitZero = true }: { emitZero?: boolean } = {}) {
@@ -379,7 +363,8 @@ export function createLiveKitAdapter<TTrack = unknown>(
       inputAnalyserResult = null
     }
 
-    if (emitZero) emitPatch({ volume: 0, inputVolume: 0 })
+    inputNormalizer.reset()
+    if (emitZero) emitPatch({ inputVolume: 0 })
   }
 
   function startInputVolumeTracking(track: LKAudioTrack) {
@@ -396,8 +381,9 @@ export function createLiveKitAdapter<TTrack = unknown>(
 
     inputVolumeInterval = setInterval(() => {
       if (!inputAnalyserResult || currentState !== 'listening') return
-      const inputVolume = normalizeMicVolume(inputAnalyserResult.calculateVolume())
-      emitPatch({ volume: inputVolume, inputVolume, outputVolume: 0 })
+      const sample = inputNormalizer.sample(inputAnalyserResult.calculateVolume())
+      config.onInputVolumeSample?.(sample)
+      emitPatch({ inputVolume: sample.normalized, outputVolume: 0 })
     }, 33)
   }
 
@@ -412,8 +398,8 @@ export function createLiveKitAdapter<TTrack = unknown>(
       outputAnalyserResult = null
     }
 
-    outputEmaVolume = 0
-    if (emitZero) emitPatch({ volume: 0, outputVolume: 0 })
+    outputNormalizer.reset()
+    if (emitZero) emitPatch({ outputVolume: 0 })
   }
 
   function startOutputVolumeTracking(track: LKRemoteAudioTrack) {
@@ -427,20 +413,23 @@ export function createLiveKitAdapter<TTrack = unknown>(
     }
 
     outputVolumeInterval = setInterval(() => {
-      if (!outputAnalyserResult || currentState !== 'speaking') return
-      const outputVolume = normalizeVolume(outputAnalyserResult.calculateVolume())
-      emitPatch({ volume: outputVolume, inputVolume: 0, outputVolume })
+      if (!outputAnalyserResult) return
+      const sample = outputNormalizer.sample(outputAnalyserResult.calculateVolume())
+      config.onOutputVolumeSample?.(sample)
+      if (currentState === 'speaking') {
+        emitPatch({ inputVolume: 0, outputVolume: sample.normalized })
+      }
     }, 33)
   }
 
   function setState(state: OrbState) {
     currentState = state
-    emitPatch({ state, volume: 0, inputVolume: 0, outputVolume: 0 })
+    inputNormalizer.reset()
+    outputNormalizer.reset()
+    emitPatch({ state, inputVolume: 0, outputVolume: 0 })
 
-    if (state === 'speaking' && agentTrack) {
+    if (agentTrack && !outputAnalyserResult) {
       startOutputVolumeTracking(agentTrack)
-    } else if (state !== 'speaking') {
-      stopOutputVolumeTracking({ emitZero: false })
     }
   }
 
@@ -460,7 +449,7 @@ export function createLiveKitAdapter<TTrack = unknown>(
   function useAgentTrack(track: LKRemoteAudioTrack) {
     agentTrack = track
     attachAudio(track)
-    if (currentState === 'speaking') startOutputVolumeTracking(track)
+    startOutputVolumeTracking(track)
   }
 
   function useLocalMicrophoneTrack(track: LKAudioTrack) {
@@ -605,7 +594,9 @@ export function createLiveKitAdapter<TTrack = unknown>(
     detachAudio()
     stopInputVolumeTracking({ emitZero: false })
     stopOutputVolumeTracking({ emitZero: false })
-    emitPatch({ volume: 0, inputVolume: 0, outputVolume: 0 })
+    inputNormalizer.reset()
+    outputNormalizer.reset()
+    emitPatch({ inputVolume: 0, outputVolume: 0 })
   }
 
   const subscribe: OrbAdapter['subscribe'] = (listener) => {

--- a/src/adapters/livekit/index.ts
+++ b/src/adapters/livekit/index.ts
@@ -380,10 +380,10 @@ export function createLiveKitAdapter<TTrack = unknown>(
     }
 
     inputVolumeInterval = setInterval(() => {
-      if (!inputAnalyserResult || currentState !== 'listening') return
+      if (!inputAnalyserResult) return
       const sample = inputNormalizer.sample(inputAnalyserResult.calculateVolume())
       config.onInputVolumeSample?.(sample)
-      emitPatch({ inputVolume: sample.normalized, outputVolume: 0 })
+      emitPatch({ inputVolume: sample.normalized })
     }, 33)
   }
 
@@ -416,17 +416,21 @@ export function createLiveKitAdapter<TTrack = unknown>(
       if (!outputAnalyserResult) return
       const sample = outputNormalizer.sample(outputAnalyserResult.calculateVolume())
       config.onOutputVolumeSample?.(sample)
-      if (currentState === 'speaking') {
-        emitPatch({ inputVolume: 0, outputVolume: sample.normalized })
-      }
+      emitPatch({ outputVolume: sample.normalized })
     }, 33)
   }
 
   function setState(state: OrbState) {
     currentState = state
-    inputNormalizer.reset()
-    outputNormalizer.reset()
-    emitPatch({ state, inputVolume: 0, outputVolume: 0 })
+    if (state === 'idle' || state === 'connecting' || state === 'error') {
+      inputNormalizer.reset()
+      outputNormalizer.reset()
+      emitPatch({ state, inputVolume: 0, outputVolume: 0 })
+    } else {
+      // State selects which directional envelope the orb renders; it should not
+      // destroy either envelope. Both meters keep running across turn changes.
+      emitPatch({ state })
+    }
 
     if (agentTrack && !outputAnalyserResult) {
       startOutputVolumeTracking(agentTrack)

--- a/src/adapters/openai-realtime/index.ts
+++ b/src/adapters/openai-realtime/index.ts
@@ -1,10 +1,7 @@
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
-import { calibrateOutputVolume } from '../audio-level'
-import type {
-  OutputVolumeCalibration,
-  OutputVolumeCalibrationSource,
-  OutputVolumeSample,
-} from '../audio-level'
+import { createVolumeNormalizer } from '../audio-level'
+import type { VolumeCalibrationSource, VolumeSample } from '../audio-level'
+import { PROVIDER_VOLUME_CALIBRATIONS } from '../volume-presets'
 
 export interface OpenAIRealtimeClientSecret {
   value: string
@@ -27,10 +24,14 @@ export interface OpenAIRealtimeAdapterConfig {
   createAudioElement?: () => HTMLAudioElement
   /** Return undefined to disable browser-side volume metering. */
   createAudioContext?: () => AudioContext | undefined
-  /** Optional live-tunable output shaping. A getter is read for every meter sample. */
-  outputVolumeCalibration?: OutputVolumeCalibrationSource
-  /** Receives raw, shaped, and smoothed output levels for diagnostics. */
-  onOutputVolumeSample?: (sample: OutputVolumeSample) => void
+  /** Optional live-tunable input calibration overrides. */
+  inputVolumeCalibration?: VolumeCalibrationSource
+  /** Optional live-tunable output calibration overrides. */
+  outputVolumeCalibration?: VolumeCalibrationSource
+  /** Receives raw, mapped, and normalized input levels for diagnostics. */
+  onInputVolumeSample?: (sample: VolumeSample) => void
+  /** Receives raw, mapped, and normalized output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: VolumeSample) => void
 }
 
 export interface OpenAIRealtimeOrbAdapter extends OrbAdapter {
@@ -50,21 +51,9 @@ interface VolumeMeter {
 const DEFAULT_CALLS_URL = 'https://api.openai.com/v1/realtime/calls'
 const OUTPUT_SPEECH_THRESHOLD = 0.015
 const OUTPUT_SILENCE_TICKS = 8
-const DEFAULT_OPENAI_OUTPUT_CALIBRATION: OutputVolumeCalibration = {
-  noiseFloor: 0.003,
-  gain: 4,
-  exponent: 0.8,
-  attack: 0.55,
-  release: 0.1,
-}
-
 function defaultCreateAudioContext() {
   const AudioContextClass = window.AudioContext
   return AudioContextClass ? new AudioContextClass() : undefined
-}
-
-function normalizeInputRms(rms: number) {
-  return Math.min(1, Math.max(0, Math.pow(rms * 4, 0.8)))
 }
 
 function createStreamVolumeMeter(
@@ -116,7 +105,7 @@ export function createOpenAIRealtimeAdapter(
   config: OpenAIRealtimeAdapterConfig,
 ): OpenAIRealtimeOrbAdapter {
   const listeners = new Set<OrbSignalListener>()
-  let signal: OrbSignal = { state: 'idle', volume: 0, inputVolume: 0, outputVolume: 0 }
+  let signal: OrbSignal = { state: 'idle', inputVolume: 0, outputVolume: 0 }
   let peerConnection: RTCPeerConnection | null = null
   let dataChannel: RTCDataChannel | null = null
   let localStream: MediaStream | null = null
@@ -124,16 +113,15 @@ export function createOpenAIRealtimeAdapter(
   let inputMeter: VolumeMeter | undefined
   let outputMeter: VolumeMeter | undefined
   let outputSilenceTicks = 0
-  let outputVolumeLevel = 0
   let stopping = false
-
-  function getOutputVolumeCalibration() {
-    const overrides =
-      typeof config.outputVolumeCalibration === 'function'
-        ? config.outputVolumeCalibration()
-        : config.outputVolumeCalibration
-    return { ...DEFAULT_OPENAI_OUTPUT_CALIBRATION, ...overrides }
-  }
+  const inputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.openai.input,
+    config.inputVolumeCalibration,
+  )
+  const outputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.openai.output,
+    config.outputVolumeCalibration,
+  )
 
   function emit(next: OrbSignal) {
     signal = next
@@ -142,10 +130,10 @@ export function createOpenAIRealtimeAdapter(
 
   function emitState(state: OrbState, error?: unknown) {
     if (signal.state === state && error === undefined) return
-    if (state !== 'speaking') outputVolumeLevel = 0
+    inputNormalizer.reset()
+    outputNormalizer.reset()
     emit({
       state,
-      volume: 0,
       inputVolume: 0,
       outputVolume: 0,
       ...(error === undefined ? {} : { error }),
@@ -154,17 +142,13 @@ export function createOpenAIRealtimeAdapter(
 
   function emitInputVolume(rawInputVolume: number) {
     if (signal.state !== 'listening') return
-    const inputVolume = normalizeInputRms(rawInputVolume)
-    emit({ ...signal, volume: inputVolume, inputVolume, outputVolume: 0 })
+    const sample = inputNormalizer.sample(rawInputVolume)
+    config.onInputVolumeSample?.(sample)
+    emit({ ...signal, inputVolume: sample.normalized, outputVolume: 0 })
   }
 
   function emitOutputVolume(rawOutputVolume: number) {
-    const sample = calibrateOutputVolume(
-      rawOutputVolume,
-      outputVolumeLevel,
-      getOutputVolumeCalibration,
-    )
-    outputVolumeLevel = sample.normalized
+    const sample = outputNormalizer.sample(rawOutputVolume)
     config.onOutputVolumeSample?.(sample)
     const outputVolume = sample.normalized
 
@@ -181,7 +165,7 @@ export function createOpenAIRealtimeAdapter(
     }
 
     if (signal.state === 'speaking') {
-      emit({ ...signal, volume: outputVolume, inputVolume: 0, outputVolume })
+      emit({ ...signal, inputVolume: 0, outputVolume })
     }
   }
 
@@ -231,7 +215,8 @@ export function createOpenAIRealtimeAdapter(
     inputMeter = undefined
     outputMeter = undefined
     outputSilenceTicks = 0
-    outputVolumeLevel = 0
+    inputNormalizer.reset()
+    outputNormalizer.reset()
     if (emitIdle) emitState('idle')
     stopping = false
   }

--- a/src/adapters/openai-realtime/index.ts
+++ b/src/adapters/openai-realtime/index.ts
@@ -130,21 +130,23 @@ export function createOpenAIRealtimeAdapter(
 
   function emitState(state: OrbState, error?: unknown) {
     if (signal.state === state && error === undefined) return
-    inputNormalizer.reset()
-    outputNormalizer.reset()
+    const resetsEnvelope = state === 'idle' || state === 'connecting' || state === 'error'
+    if (resetsEnvelope) {
+      inputNormalizer.reset()
+      outputNormalizer.reset()
+    }
     emit({
+      ...signal,
       state,
-      inputVolume: 0,
-      outputVolume: 0,
+      ...(resetsEnvelope ? { inputVolume: 0, outputVolume: 0 } : {}),
       ...(error === undefined ? {} : { error }),
     })
   }
 
   function emitInputVolume(rawInputVolume: number) {
-    if (signal.state !== 'listening') return
     const sample = inputNormalizer.sample(rawInputVolume)
     config.onInputVolumeSample?.(sample)
-    emit({ ...signal, inputVolume: sample.normalized, outputVolume: 0 })
+    emit({ ...signal, inputVolume: sample.normalized })
   }
 
   function emitOutputVolume(rawOutputVolume: number) {
@@ -164,9 +166,7 @@ export function createOpenAIRealtimeAdapter(
       }
     }
 
-    if (signal.state === 'speaking') {
-      emit({ ...signal, inputVolume: 0, outputVolume })
-    }
+    emit({ ...signal, outputVolume })
   }
 
   function handleServerEvent(event: RealtimeServerEvent) {

--- a/src/adapters/openai-realtime/index.ts
+++ b/src/adapters/openai-realtime/index.ts
@@ -113,6 +113,11 @@ export function createOpenAIRealtimeAdapter(
   let inputMeter: VolumeMeter | undefined
   let outputMeter: VolumeMeter | undefined
   let outputSilenceTicks = 0
+  // WebRTC playback events are authoritative once available. A decaying
+  // volume envelope must not reopen speech after a stop or end a buffer that
+  // has started but whose first audio packet has not arrived yet.
+  let outputPlaybackState: 'unknown' | 'playing' | 'stopped' = 'unknown'
+  let userSpeaking = false
   let stopping = false
   const inputNormalizer = createVolumeNormalizer(
     PROVIDER_VOLUME_CALIBRATIONS.openai.input,
@@ -154,15 +159,22 @@ export function createOpenAIRealtimeAdapter(
     config.onOutputVolumeSample?.(sample)
     const outputVolume = sample.normalized
 
-    if (outputVolume > OUTPUT_SPEECH_THRESHOLD) {
-      outputSilenceTicks = 0
-      if (signal.state !== 'speaking') emitState('speaking')
-    } else if (signal.state === 'speaking') {
-      outputSilenceTicks += 1
-      if (outputSilenceTicks >= OUTPUT_SILENCE_TICKS) {
+    const canInferPlayback =
+      outputPlaybackState === 'unknown' &&
+      !userSpeaking &&
+      signal.state !== 'idle' &&
+      signal.state !== 'connecting' &&
+      signal.state !== 'error'
+    if (canInferPlayback) {
+      if (outputVolume > OUTPUT_SPEECH_THRESHOLD) {
         outputSilenceTicks = 0
-        emitState('listening')
-        return
+        if (signal.state !== 'speaking') emitState('speaking')
+      } else if (signal.state === 'speaking') {
+        outputSilenceTicks += 1
+        if (outputSilenceTicks >= OUTPUT_SILENCE_TICKS) {
+          outputSilenceTicks = 0
+          emitState('listening')
+        }
       }
     }
 
@@ -176,17 +188,28 @@ export function createOpenAIRealtimeAdapter(
         emitState('listening')
         break
       case 'input_audio_buffer.speech_started':
+        userSpeaking = true
         emitState('listening')
         break
       case 'input_audio_buffer.speech_stopped':
+        userSpeaking = false
+        emitState(outputPlaybackState === 'playing' ? 'speaking' : 'thinking')
+        break
       case 'response.created':
-        emitState('thinking')
+        if (!userSpeaking && outputPlaybackState !== 'playing') emitState('thinking')
         break
       case 'response.output_audio.delta':
+        if (!userSpeaking) emitState('speaking')
+        break
       case 'output_audio_buffer.started':
-        emitState('speaking')
+        outputPlaybackState = 'playing'
+        outputSilenceTicks = 0
+        if (!userSpeaking) emitState('speaking')
         break
       case 'output_audio_buffer.stopped':
+      case 'output_audio_buffer.cleared':
+        outputPlaybackState = 'stopped'
+        outputSilenceTicks = 0
         emitState('listening')
         break
       case 'response.done':
@@ -215,6 +238,8 @@ export function createOpenAIRealtimeAdapter(
     inputMeter = undefined
     outputMeter = undefined
     outputSilenceTicks = 0
+    outputPlaybackState = 'unknown'
+    userSpeaking = false
     inputNormalizer.reset()
     outputNormalizer.reset()
     if (emitIdle) emitState('idle')

--- a/src/adapters/openai-realtime/playback.test.ts
+++ b/src/adapters/openai-realtime/playback.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createOpenAIRealtimeAdapter } from './index'
+import type { OrbSignal } from '../types'
+
+afterEach(() => vi.useRealTimers())
+
+async function meteredSession() {
+  const track = { stop: vi.fn(), kind: 'audio' } as unknown as MediaStreamTrack
+  const input = {
+    getTracks: () => [track],
+    getAudioTracks: () => [track],
+  } as unknown as MediaStream
+  const output = {} as MediaStream
+  let outputLevel = 0
+  const channel = {
+    onopen: null as (() => void) | null,
+    onmessage: null as ((event: MessageEvent) => void) | null,
+    close: vi.fn(),
+  }
+  const peer = {
+    ontrack: null as ((event: RTCTrackEvent) => void) | null,
+    addTrack: vi.fn(),
+    createDataChannel: () => channel,
+    createOffer: async () => ({ type: 'offer', sdp: 'offer-sdp' }),
+    setLocalDescription: vi.fn(),
+    setRemoteDescription: vi.fn(),
+    close: vi.fn(),
+  }
+  const adapter = createOpenAIRealtimeAdapter({
+    getClientSecret: async () => 'ephemeral-secret',
+    getUserMedia: async () => input,
+    createPeerConnection: () => peer as unknown as RTCPeerConnection,
+    createAudioElement: () =>
+      ({
+        play: vi.fn(async () => undefined),
+        pause: vi.fn(),
+        remove: vi.fn(),
+      }) as unknown as HTMLAudioElement,
+    createAudioContext: () => {
+      let source: MediaStream
+      return {
+        state: 'running',
+        close: vi.fn(async () => undefined),
+        createMediaStreamSource: (stream: MediaStream) => {
+          source = stream
+          return { connect: vi.fn(), disconnect: vi.fn() }
+        },
+        createAnalyser: () => ({
+          fftSize: 512,
+          smoothingTimeConstant: 0,
+          getFloatTimeDomainData: (samples: Float32Array) =>
+            samples.fill(source === output ? outputLevel : 0.05),
+          disconnect: vi.fn(),
+        }),
+      } as unknown as AudioContext
+    },
+    fetch: vi.fn(async () => new Response('answer-sdp')) as typeof fetch,
+  })
+  const signals: OrbSignal[] = []
+  adapter.subscribe((signal) => signals.push(signal))
+  const attach = () => {
+    channel.onopen?.()
+    peer.ontrack?.({ streams: [output], track } as unknown as RTCTrackEvent)
+  }
+  await adapter.start()
+  attach()
+  return {
+    adapter,
+    signals,
+    attach,
+    event: (type: string) =>
+      channel.onmessage?.({ data: JSON.stringify({ type }) } as MessageEvent),
+    setOutput: (value: number) => {
+      outputLevel = value
+    },
+  }
+}
+
+describe('OpenAI playback priority', () => {
+  it('keeps server playback boundaries stable through delayed packets, envelope tails, and interruption', async () => {
+    vi.useFakeTimers()
+    const { adapter, signals, event, setOutput } = await meteredSession()
+    event('output_audio_buffer.started')
+    const started = signals.length
+    // First packets can arrive after buffer-start. Silence must not flash listening.
+    vi.advanceTimersByTime(400)
+    expect(signals.slice(started).every((signal) => signal.state === 'speaking')).toBe(true)
+    setOutput(0.1)
+    vi.advanceTimersByTime(300)
+    expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0.3)
+    event('output_audio_buffer.stopped')
+    setOutput(0)
+    const stopped = signals.length
+    vi.advanceTimersByTime(33)
+    expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0.2)
+    vi.advanceTimersByTime(1000)
+    expect(signals.slice(stopped).every((signal) => signal.state === 'listening')).toBe(true)
+
+    event('output_audio_buffer.started')
+    setOutput(0.1)
+    vi.advanceTimersByTime(200)
+    event('input_audio_buffer.speech_started')
+    const interrupted = signals.length
+    event('response.created')
+    event('response.output_audio.delta')
+    vi.advanceTimersByTime(200)
+    expect(signals.slice(interrupted).every((signal) => signal.state === 'listening')).toBe(true)
+    event('output_audio_buffer.cleared')
+    event('input_audio_buffer.speech_stopped')
+    expect(signals.at(-1)?.state).toBe('thinking')
+    event('output_audio_buffer.started')
+    expect(signals.at(-1)?.state).toBe('speaking')
+    await adapter.stop()
+  })
+
+  it('retains meter fallback when playback events are unavailable, including after restart', async () => {
+    vi.useFakeTimers()
+    const { adapter, signals, event, setOutput, attach } = await meteredSession()
+    setOutput(0.1)
+    vi.advanceTimersByTime(200)
+    expect(signals.at(-1)?.state).toBe('speaking')
+    setOutput(0)
+    vi.advanceTimersByTime(1500)
+    expect(signals.at(-1)?.state).toBe('listening')
+    event('output_audio_buffer.stopped')
+    await adapter.stop()
+    await adapter.start()
+    attach()
+    setOutput(0.1)
+    vi.advanceTimersByTime(200)
+    expect(signals.at(-1)?.state).toBe('speaking')
+    event('error')
+    vi.advanceTimersByTime(200)
+    expect(signals.at(-1)?.state).toBe('error')
+    await adapter.stop()
+  })
+})

--- a/src/adapters/pipecat/index.test.ts
+++ b/src/adapters/pipecat/index.test.ts
@@ -86,8 +86,7 @@ describe('createPipecatAdapter', () => {
       state: 'listening',
       outputVolume: 0,
     })
-    expect(signals.at(-1)?.volume).toBeCloseTo(0.6)
-    expect(signals.at(-1)?.inputVolume).toBeCloseTo(0.6)
+    expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
 
     client.emit('userStoppedSpeaking')
     expect(signals.at(-1)).toMatchObject({ state: 'thinking' })
@@ -98,8 +97,7 @@ describe('createPipecatAdapter', () => {
       state: 'speaking',
       inputVolume: 0,
     })
-    expect(signals.at(-1)?.volume).toBeCloseTo(0.5)
-    expect(signals.at(-1)?.outputVolume).toBeCloseTo(0.5)
+    expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
 
     client.emit('botStoppedSpeaking')
     expect(signals.at(-1)).toMatchObject({ state: 'listening', outputVolume: 0 })
@@ -172,10 +170,10 @@ describe('createPipecatAdapter', () => {
     expect(signals).toHaveLength(count)
 
     client.emit('remoteAudioLevel', 0.8, { id: 'bot', local: false })
-    expect(signals.at(-1)?.outputVolume).toBeCloseTo(0.5)
+    expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
   })
 
-  it('amplifies realistic low levels and smooths attack and release independently', () => {
+  it('amplifies realistic low levels and follows rise and fall independently', () => {
     const client = new FakePipecatClient()
     const adapter = createPipecatAdapter(client)
     const signals: OrbSignal[] = []
@@ -184,7 +182,7 @@ describe('createPipecatAdapter', () => {
     client.emit('botReady')
     client.emit('localAudioLevel', 0.02)
     const firstInput = signals.at(-1)?.inputVolume ?? 0
-    expect(firstInput).toBeGreaterThan(0.07)
+    expect(firstInput).toBeGreaterThan(0.05)
 
     client.emit('localAudioLevel', 0.02)
     const secondInput = signals.at(-1)?.inputVolume ?? 0

--- a/src/adapters/pipecat/index.test.ts
+++ b/src/adapters/pipecat/index.test.ts
@@ -95,12 +95,17 @@ describe('createPipecatAdapter', () => {
     client.emit('remoteAudioLevel', 0.7, { id: 'bot', local: false })
     expect(signals.at(-1)).toMatchObject({
       state: 'speaking',
-      inputVolume: 0,
+      inputVolume: expect.any(Number),
     })
+    expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
     expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
 
+    const speakingOutput = signals.at(-1)?.outputVolume ?? 0
     client.emit('botStoppedSpeaking')
-    expect(signals.at(-1)).toMatchObject({ state: 'listening', outputVolume: 0 })
+    expect(signals.at(-1)).toMatchObject({
+      state: 'listening',
+      outputVolume: speakingOutput,
+    })
 
     await adapter.stop()
     expect(client.disconnect).toHaveBeenCalledOnce()
@@ -139,12 +144,14 @@ describe('createPipecatAdapter', () => {
 
     client.emit('botReady')
     vi.advanceTimersByTime(33)
-    expect(signals.at(-1)).toMatchObject({ state: 'listening', outputVolume: 0 })
+    expect(signals.at(-1)).toMatchObject({ state: 'listening' })
     expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
+    expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
 
     client.emit('botStartedSpeaking')
     vi.advanceTimersByTime(33)
-    expect(signals.at(-1)).toMatchObject({ state: 'speaking', inputVolume: 0 })
+    expect(signals.at(-1)).toMatchObject({ state: 'speaking' })
+    expect(signals.at(-1)?.inputVolume).toBeGreaterThan(0)
     expect(signals.at(-1)?.outputVolume).toBeGreaterThan(0)
     expect(onOutputVolumeSample).toHaveBeenCalledWith(
       expect.objectContaining({ raw: expect.closeTo(0.16) }),
@@ -197,7 +204,7 @@ describe('createPipecatAdapter', () => {
     client.emit('remoteAudioLevel', 0.05, { id: 'bot', local: false })
     const output = signals.at(-1)?.outputVolume ?? 0
     expect(output).toBeGreaterThan(0.15)
-    expect(signals.at(-1)?.inputVolume).toBe(0)
+    expect(signals.at(-1)?.inputVolume).toBe(releasedInput)
   })
 
   it('gates invalid and near-silent levels', () => {

--- a/src/adapters/pipecat/index.test.ts
+++ b/src/adapters/pipecat/index.test.ts
@@ -69,6 +69,32 @@ afterEach(() => {
 })
 
 describe('createPipecatAdapter', () => {
+  it.each(['botLlmStarted', 'botTtsStarted'])(
+    'keeps playback reactive when %s arrives during speech',
+    (event) => {
+      const client = new FakePipecatClient()
+      const adapter = createPipecatAdapter(client)
+      let current: OrbSignal = { state: 'idle' }
+      const unsubscribe = adapter.subscribe((signal) => (current = signal))
+
+      client.emit('botReady')
+      client.emit(event)
+      expect(current.state).toBe('thinking')
+      client.emit('botStartedSpeaking')
+      client.emit('remoteAudioLevel', 0.08)
+      const output = current.outputVolume
+      client.emit(event)
+      expect(current).toMatchObject({ state: 'speaking', outputVolume: output })
+
+      client.emit('userStartedSpeaking')
+      expect(current.state).toBe('listening')
+      client.emit('botStoppedSpeaking')
+      client.emit(event)
+      expect(current.state).toBe('thinking')
+      unsubscribe()
+    },
+  )
+
   it('normalizes RTVI lifecycle, speaking, and audio-level events', async () => {
     const client = new FakePipecatClient()
     const connect = vi.fn(async () => undefined)

--- a/src/adapters/pipecat/index.ts
+++ b/src/adapters/pipecat/index.ts
@@ -1,12 +1,12 @@
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
-import { calibrateOutputVolume, createMediaStreamTrackVolumeMeter } from '../audio-level'
+import { createMediaStreamTrackVolumeMeter, createVolumeNormalizer } from '../audio-level'
 import type {
   AudioContextSource,
   MediaStreamTrackVolumeMeter,
-  OutputVolumeCalibration,
-  OutputVolumeCalibrationSource,
-  OutputVolumeSample,
+  VolumeCalibrationSource,
+  VolumeSample,
 } from '../audio-level'
+import { PROVIDER_VOLUME_CALIBRATIONS } from '../volume-presets'
 
 type PipecatListener = (...args: unknown[]) => void
 
@@ -51,10 +51,14 @@ export interface PipecatAdapterOptions {
   createAudioElement?: () => HTMLAudioElement
   /** Return undefined to disable browser-track volume metering. */
   createAudioContext?: AudioContextSource
-  /** Optional live-tunable output shaping. A getter is read for every meter sample. */
-  outputVolumeCalibration?: OutputVolumeCalibrationSource
-  /** Receives raw, shaped, and smoothed output levels for diagnostics. */
-  onOutputVolumeSample?: (sample: OutputVolumeSample) => void
+  /** Optional live-tunable input calibration overrides. */
+  inputVolumeCalibration?: VolumeCalibrationSource
+  /** Optional live-tunable output calibration overrides. */
+  outputVolumeCalibration?: VolumeCalibrationSource
+  /** Receives raw, mapped, and normalized input levels for diagnostics. */
+  onInputVolumeSample?: (sample: VolumeSample) => void
+  /** Receives raw, mapped, and normalized output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: VolumeSample) => void
 }
 
 export interface PipecatOrbAdapter extends OrbAdapter {
@@ -80,23 +84,6 @@ const PIPECAT_EVENTS = {
   botLlmStarted: 'botLlmStarted',
   botTtsStarted: 'botTtsStarted',
 } as const
-
-// Daily/Pipecat reports audio gain in the full 0-1 range, but conversational
-// speech commonly occupies only the bottom few hundredths of that range. Shape
-// those values before they reach a theme so quiet speech still produces useful
-// motion, then smooth the 100 ms level updates without making speech feel laggy.
-const INPUT_AUDIO_LEVEL_NOISE_FLOOR = 0.002
-const INPUT_AUDIO_LEVEL_GAIN = 4
-const INPUT_AUDIO_LEVEL_EXPONENT = 0.8
-const INPUT_AUDIO_LEVEL_ATTACK = 0.6
-const INPUT_AUDIO_LEVEL_RELEASE = 0.2
-const DEFAULT_PIPECAT_OUTPUT_CALIBRATION: OutputVolumeCalibration = {
-  noiseFloor: 0.002,
-  gain: 5.1,
-  exponent: 0.8,
-  attack: 0.5,
-  release: 0.22,
-}
 
 function defaultCreateAudioContext() {
   if (typeof window === 'undefined') return undefined
@@ -125,25 +112,6 @@ function stateFromTransport(state: string): OrbState | undefined {
   }
 }
 
-function shapeAudioLevel(level: unknown): number {
-  if (
-    typeof level !== 'number' ||
-    !Number.isFinite(level) ||
-    level <= INPUT_AUDIO_LEVEL_NOISE_FLOOR
-  ) {
-    return 0
-  }
-
-  const gated = Math.min(1, Math.max(0, level - INPUT_AUDIO_LEVEL_NOISE_FLOOR))
-  return Math.pow(Math.min(1, gated * INPUT_AUDIO_LEVEL_GAIN), INPUT_AUDIO_LEVEL_EXPONENT)
-}
-
-function smoothAudioLevel(level: unknown, previous: number): number {
-  const shaped = shapeAudioLevel(level)
-  const rate = shaped > previous ? INPUT_AUDIO_LEVEL_ATTACK : INPUT_AUDIO_LEVEL_RELEASE
-  return previous + (shaped - previous) * rate
-}
-
 function isMediaStreamTrack(track: unknown): track is MediaStreamTrack {
   return (
     typeof track === 'object' &&
@@ -167,25 +135,22 @@ export function createPipecatAdapter(
   const remoteAudioElements = new Map<MediaStreamTrack, HTMLAudioElement>()
   let signal: OrbSignal = {
     state: stateFromTransport(client.state ?? '') ?? 'idle',
-    volume: 0,
     inputVolume: 0,
     outputVolume: 0,
   }
   let listening = false
-  let inputLevel = 0
-  let outputLevel = 0
   let inputMeterTrack: MediaStreamTrack | null = null
   let outputMeterTrack: MediaStreamTrack | null = null
   let inputMeter: MediaStreamTrackVolumeMeter | undefined
   let outputMeter: MediaStreamTrackVolumeMeter | undefined
-
-  function getOutputVolumeCalibration() {
-    const overrides =
-      typeof options.outputVolumeCalibration === 'function'
-        ? options.outputVolumeCalibration()
-        : options.outputVolumeCalibration
-    return { ...DEFAULT_PIPECAT_OUTPUT_CALIBRATION, ...overrides }
-  }
+  const inputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.pipecat.input,
+    options.inputVolumeCalibration,
+  )
+  const outputNormalizer = createVolumeNormalizer(
+    PROVIDER_VOLUME_CALIBRATIONS.pipecat.output,
+    options.outputVolumeCalibration,
+  )
 
   function emit(next: OrbSignal) {
     signal = next
@@ -193,11 +158,10 @@ export function createPipecatAdapter(
   }
 
   function emitState(state: OrbState, error?: unknown) {
-    inputLevel = 0
-    outputLevel = 0
+    inputNormalizer.reset()
+    outputNormalizer.reset()
     emit({
       state,
-      volume: 0,
       inputVolume: 0,
       outputVolume: 0,
       ...(error === undefined ? {} : { error }),
@@ -206,14 +170,12 @@ export function createPipecatAdapter(
 
   function emitInputVolume(level: unknown) {
     if (signal.state !== 'listening') return
-    inputLevel = smoothAudioLevel(level, inputLevel)
-    const inputVolume = inputLevel
-    emit({ ...signal, volume: inputVolume, inputVolume, outputVolume: 0 })
+    const sample = inputNormalizer.sample(typeof level === 'number' ? level : 0)
+    options.onInputVolumeSample?.(sample)
+    emit({ ...signal, inputVolume: sample.normalized, outputVolume: 0 })
   }
 
   function emitOutputVolume(level: unknown, participant?: unknown) {
-    if (signal.state !== 'speaking') return
-
     if (participant && typeof participant === 'object') {
       const candidate = participant as PipecatParticipantLike
       if (candidate.local || (options.isBotParticipant && !options.isBotParticipant(candidate))) {
@@ -221,15 +183,11 @@ export function createPipecatAdapter(
       }
     }
 
-    const sample = calibrateOutputVolume(
-      typeof level === 'number' ? level : 0,
-      outputLevel,
-      getOutputVolumeCalibration,
-    )
-    outputLevel = sample.normalized
+    const sample = outputNormalizer.sample(typeof level === 'number' ? level : 0)
     options.onOutputVolumeSample?.(sample)
-    const outputVolume = sample.normalized
-    emit({ ...signal, volume: outputVolume, inputVolume: 0, outputVolume })
+    if (signal.state === 'speaking') {
+      emit({ ...signal, inputVolume: 0, outputVolume: sample.normalized })
+    }
   }
 
   function stopInputMeter() {

--- a/src/adapters/pipecat/index.ts
+++ b/src/adapters/pipecat/index.ts
@@ -158,21 +158,23 @@ export function createPipecatAdapter(
   }
 
   function emitState(state: OrbState, error?: unknown) {
-    inputNormalizer.reset()
-    outputNormalizer.reset()
+    const resetsEnvelope = state === 'idle' || state === 'connecting' || state === 'error'
+    if (resetsEnvelope) {
+      inputNormalizer.reset()
+      outputNormalizer.reset()
+    }
     emit({
+      ...signal,
       state,
-      inputVolume: 0,
-      outputVolume: 0,
+      ...(resetsEnvelope ? { inputVolume: 0, outputVolume: 0 } : {}),
       ...(error === undefined ? {} : { error }),
     })
   }
 
   function emitInputVolume(level: unknown) {
-    if (signal.state !== 'listening') return
     const sample = inputNormalizer.sample(typeof level === 'number' ? level : 0)
     options.onInputVolumeSample?.(sample)
-    emit({ ...signal, inputVolume: sample.normalized, outputVolume: 0 })
+    emit({ ...signal, inputVolume: sample.normalized })
   }
 
   function emitOutputVolume(level: unknown, participant?: unknown) {
@@ -185,9 +187,7 @@ export function createPipecatAdapter(
 
     const sample = outputNormalizer.sample(typeof level === 'number' ? level : 0)
     options.onOutputVolumeSample?.(sample)
-    if (signal.state === 'speaking') {
-      emit({ ...signal, inputVolume: 0, outputVolume: sample.normalized })
-    }
+    emit({ ...signal, outputVolume: sample.normalized })
   }
 
   function stopInputMeter() {

--- a/src/adapters/pipecat/index.ts
+++ b/src/adapters/pipecat/index.ts
@@ -309,6 +309,12 @@ export function createPipecatAdapter(
     syncTrackMeters()
   }
 
+  function handleBotGenerationStarted() {
+    // Generation can overlap playback of an earlier sentence. Keep following
+    // audio until playback stops or the user interrupts the bot.
+    if (signal.state !== 'speaking') emitState('thinking')
+  }
+
   const eventHandlers: Array<[string, PipecatListener]> = [
     [PIPECAT_EVENTS.connected, () => emitState('connecting')],
     [PIPECAT_EVENTS.botReady, handleBotReady],
@@ -329,8 +335,8 @@ export function createPipecatAdapter(
         if (signal.state === 'listening') emitState('thinking')
       },
     ],
-    [PIPECAT_EVENTS.botLlmStarted, () => emitState('thinking')],
-    [PIPECAT_EVENTS.botTtsStarted, () => emitState('thinking')],
+    [PIPECAT_EVENTS.botLlmStarted, handleBotGenerationStarted],
+    [PIPECAT_EVENTS.botTtsStarted, handleBotGenerationStarted],
     [PIPECAT_EVENTS.botStartedSpeaking, () => emitState('speaking')],
     [PIPECAT_EVENTS.botStoppedSpeaking, () => emitState('listening')],
     [PIPECAT_EVENTS.localAudioLevel, (level) => !inputMeter && emitInputVolume(level)],

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -6,13 +6,3 @@ import type {
 } from '../components/Orb/Orb.types'
 
 export type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState }
-
-/**
- * Shared mic volume curve — rescale real-world mic range to 0–1 with pow shaping
- * for custom provider adapters that need browser-side input metering.
- */
-export function normalizeMicVolume(v: number): number {
-  let vol = Math.min(v / 0.5, 1.0)
-  vol = Math.pow(vol, 1.3)
-  return vol
-}

--- a/src/adapters/vapi/index.ts
+++ b/src/adapters/vapi/index.ts
@@ -1,4 +1,7 @@
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
+import { createVolumeNormalizer } from '../audio-level'
+import type { VolumeCalibrationSource, VolumeSample } from '../audio-level'
+import { PROVIDER_VOLUME_CALIBRATIONS } from '../volume-presets'
 
 // Minimal interface for the Vapi client from @vapi-ai/web.
 // We define our own so orb-ui doesn't require @vapi-ai/web as a dependency —
@@ -38,13 +41,9 @@ interface VapiMessage {
 //    not actual silence between words. Without treatment it causes visible
 //    jitter in any animation driven by this signal.
 //
-// Normalization pipeline (runs at Vapi tick rate, ~10 Hz):
-//   a. Noise gate — anything below NOISE_FLOOR is treated as silence (→ 0).
-//   b. Linear ramp — rescales the gated value to the full 0–1 range.
-//   c. EMA — smooths the alternating loud/silent pattern.
-//      Fast attack (0.65) catches new speech; slow release (0.12) bridges dips.
-
-const NOISE_FLOOR = 0.12
+// A short source-specific hold removes the alternating false-zero artifact
+// before the canonical elapsed-time envelope is applied.
+const DROPOUT_HOLD_MS = 160
 
 // ─── Vapi-specific state debouncing ──────────────────────────────────────────
 //
@@ -95,16 +94,20 @@ function makeStateEmitter(onStateChange: (s: OrbState) => void) {
  *   call-end                               → 'idle'
  *   error                                  → 'error'
  *
- * Volume: raw Vapi values are normalized (noise gate + EMA) before being emitted
- * as outputVolume while the assistant is speaking.
+ * Volume: raw Vapi values are mapped through the provider profile and emitted
+ * as a stable normalized outputVolume envelope while the assistant is speaking.
  *
  * @param client  - A Vapi instance from @vapi-ai/web
  * @param options - Optional config (e.g. assistantId to pass to vapi.start())
  */
 
-interface VapiAdapterOptions {
+export interface VapiAdapterOptions {
   /** Assistant ID passed to vapi.start() when the orb is clicked. */
   assistantId?: string
+  /** Optional live-tunable output calibration overrides. */
+  outputVolumeCalibration?: VolumeCalibrationSource
+  /** Receives raw, mapped, and normalized output levels for diagnostics. */
+  onOutputVolumeSample?: (sample: VolumeSample) => void
 }
 
 export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptions): OrbAdapter {
@@ -138,16 +141,11 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
     },
 
     subscribe(listener: OrbSignalListener) {
-      let signal: OrbSignal = { state: 'idle', volume: 0, outputVolume: 0 }
-      let emaVol = 0
-
-      function normalizeVapiVolume(raw: number): number {
-        const gated = raw < NOISE_FLOOR ? 0 : (raw - NOISE_FLOOR) / (1 - NOISE_FLOOR)
-        // Light EMA to bridge Vapi's alternating loud/silent artifact
-        const rate = gated > emaVol ? 0.8 : 0.5
-        emaVol = emaVol + (gated - emaVol) * rate
-        return emaVol
-      }
+      let signal: OrbSignal = { state: 'idle', outputVolume: 0 }
+      const outputNormalizer = createVolumeNormalizer(
+        PROVIDER_VOLUME_CALIBRATIONS.vapi.output,
+        options?.outputVolumeCalibration,
+      )
 
       function emitSignal(nextSignal: OrbSignal) {
         signal = nextSignal
@@ -169,7 +167,7 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
         callActive = true
         currentState = 'listening'
         emitState('listening')
-        emitPatch({ volume: 0, outputVolume: 0 })
+        emitPatch({ outputVolume: 0 })
       }
 
       const onCallEnd = () => {
@@ -177,15 +175,14 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
         currentState = 'idle'
         stopVolLoop()
         emitState('idle')
-        emitPatch({ volume: 0, outputVolume: 0 })
-        emaVol = 0
+        emitPatch({ outputVolume: 0 })
       }
 
       const onSpeechStart = () => {
         if (!callActive) return
         currentState = 'speaking'
         emitState('speaking')
-        emitPatch({ volume: 0, outputVolume: 0 })
+        emitPatch({ outputVolume: 0 })
         startVolLoop()
       }
 
@@ -193,21 +190,23 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
         if (!callActive) return
         stopVolLoop()
         currentState = 'listening'
-        emitPatch({ volume: 0, outputVolume: 0 })
-        emaVol = 0
+        emitPatch({ outputVolume: 0 })
         emitState('listening')
       }
 
-      // ── 60fps interpolation loop ──────────────────────────────────────
-      // Vapi emits volume at ~10Hz. We lerp at 60fps so themes get smooth data.
-      let targetVol = 0
-      let currentVol = 0
+      // Vapi emits volume at ~10Hz. Sample its latest level per frame so elapsed-
+      // time envelope behavior remains smooth and consistent with other providers.
+      let targetRawVolume = 0
+      let heldRawVolume = 0
+      let lastActiveSampleAt = 0
       let volRaf = 0
 
-      const volLoop = () => {
+      const volLoop = (now: number) => {
         if (currentState === 'speaking') {
-          currentVol += (targetVol - currentVol) * 0.1
-          emitPatch({ volume: currentVol, outputVolume: currentVol })
+          const raw = now - lastActiveSampleAt <= DROPOUT_HOLD_MS ? heldRawVolume : targetRawVolume
+          const sample = outputNormalizer.sample(raw, now)
+          options?.onOutputVolumeSample?.(sample)
+          emitPatch({ outputVolume: sample.normalized })
         }
         volRaf = requestAnimationFrame(volLoop)
       }
@@ -220,16 +219,20 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
           cancelAnimationFrame(volRaf)
           volRaf = 0
         }
-        currentVol = 0
-        targetVol = 0
+        targetRawVolume = 0
+        heldRawVolume = 0
+        lastActiveSampleAt = 0
+        outputNormalizer.reset()
       }
 
       const onVolumeLevel = (volume: number) => {
-        // Only use Vapi's volume-level for speaking (AI output)
-        // Apply sigmoid curve, then set target for the 60fps lerp loop
+        // Only use Vapi's volume-level for speaking (AI output).
         if (currentState === 'speaking') {
-          const normalized = normalizeVapiVolume(volume)
-          targetVol = normalized / (normalized + 0.3)
+          targetRawVolume = volume
+          if (volume > PROVIDER_VOLUME_CALIBRATIONS.vapi.output.amplitude.silenceFloor) {
+            heldRawVolume = volume
+            lastActiveSampleAt = performance.now()
+          }
         }
       }
 
@@ -243,8 +246,7 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
         currentState = 'error'
         clearTimer()
         stopVolLoop()
-        emitPatch({ state: 'error', volume: 0, outputVolume: 0, error })
-        emaVol = 0
+        emitPatch({ state: 'error', outputVolume: 0, error })
       }
 
       client.on('call-start', onCallStart)
@@ -262,7 +264,6 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
       return () => {
         clearTimer()
         stopVolLoop()
-        emaVol = 0
         client.removeListener('call-start', onCallStart as () => void)
         client.removeListener('call-end', onCallEnd as () => void)
         client.removeListener('speech-start', onSpeechStart as () => void)

--- a/src/adapters/vapi/index.ts
+++ b/src/adapters/vapi/index.ts
@@ -156,7 +156,15 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
         emitSignal({ ...signal, ...patch, state: patch.state ?? signal.state })
       }
 
-      const { emitState, clearTimer } = makeStateEmitter((state) => emitPatch({ state }))
+      const { emitState, clearTimer } = makeStateEmitter((state) => {
+        currentState = state
+        if (state === 'listening') {
+          stopVolLoop()
+          emitPatch({ state, outputVolume: 0 })
+        } else {
+          emitPatch({ state })
+        }
+      })
       const onStart = () => emitState('connecting')
 
       // Track current state so we can gate volume sources
@@ -165,9 +173,7 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
 
       const onCallStart = () => {
         callActive = true
-        currentState = 'listening'
         emitState('listening')
-        emitPatch({ outputVolume: 0 })
       }
 
       const onCallEnd = () => {
@@ -180,17 +186,18 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
 
       const onSpeechStart = () => {
         if (!callActive) return
-        currentState = 'speaking'
         emitState('speaking')
-        emitPatch({ outputVolume: 0 })
         startVolLoop()
       }
 
       const onSpeechEnd = () => {
         if (!callActive) return
-        stopVolLoop()
-        currentState = 'listening'
-        emitPatch({ outputVolume: 0 })
+        // Keep the rAF sampler alive while the debounced speaking state and
+        // canonical fall envelope finish. Resetting here made output snap to
+        // zero up to 350ms before the state actually changed.
+        targetRawVolume = 0
+        heldRawVolume = 0
+        lastActiveSampleAt = 0
         emitState('listening')
       }
 

--- a/src/adapters/vapi/index.ts
+++ b/src/adapters/vapi/index.ts
@@ -1,6 +1,11 @@
 import type { OrbAdapter, OrbSignal, OrbSignalListener, OrbState } from '../types'
-import { createVolumeNormalizer } from '../audio-level'
-import type { VolumeCalibrationSource, VolumeSample } from '../audio-level'
+import { createMediaStreamTrackVolumeMeter, createVolumeNormalizer } from '../audio-level'
+import type {
+  AudioContextSource,
+  MediaStreamTrackVolumeMeter,
+  VolumeCalibrationSource,
+  VolumeSample,
+} from '../audio-level'
 import { PROVIDER_VOLUME_CALIBRATIONS } from '../volume-presets'
 
 // Minimal interface for the Vapi client from @vapi-ai/web.
@@ -18,6 +23,20 @@ interface VapiClient {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   start(...args: any[]): Promise<unknown>
   stop(): void
+  /** Public SDK access to the existing call's microphone; no second capture. */
+  getDailyCallObject?(): {
+    participants(): {
+      local?: {
+        tracks?: {
+          audio?: {
+            state?: string
+            persistentTrack?: MediaStreamTrack
+            track?: MediaStreamTrack
+          }
+        }
+      }
+    }
+  } | null
 }
 
 interface VapiMessage {
@@ -29,20 +48,10 @@ interface VapiMessage {
 
 // ─── Vapi-specific volume normalization ───────────────────────────────────────
 //
-// Vapi's volume-level events have two quirks that must be handled before the
-// signal reaches the visual layer:
-//
-// 1. QUANTIZED VALUES — Vapi only ever emits 6 discrete levels:
-//       0, 0.000667, 0.00667, 0.0667, 0.667, 1.0   (each ~10× the previous)
-//    These are not a continuous signal; they're essentially log-scale buckets.
-//
-// 2. ALTERNATING PATTERN — During speech, values frequently alternate between
-//    loud (0.667 / 1.0) and near-zero every ~100ms. This is a Vapi artifact,
-//    not actual silence between words. Without treatment it causes visible
-//    jitter in any animation driven by this signal.
-//
-// A short source-specific hold removes the alternating false-zero artifact
-// before the canonical elapsed-time envelope is applied.
+// Vapi forwards Daily remote participant levels at roughly 10Hz, scaled by
+// 1 / 0.15 and capped at 1. Some audio paths alternate between active and
+// near-zero samples; a short hold softens those dropouts before the canonical
+// elapsed-time envelope. Current SDK values can be continuous, not just buckets.
 const DROPOUT_HOLD_MS = 160
 
 // ─── Vapi-specific state debouncing ──────────────────────────────────────────
@@ -96,6 +105,7 @@ function makeStateEmitter(onStateChange: (s: OrbState) => void) {
  *
  * Volume: raw Vapi values are mapped through the provider profile and emitted
  * as a stable normalized outputVolume envelope while the assistant is speaking.
+ * Input: meters the SDK-owned local audio track when getDailyCallObject exists.
  *
  * @param client  - A Vapi instance from @vapi-ai/web
  * @param options - Optional config (e.g. assistantId to pass to vapi.start())
@@ -104,14 +114,21 @@ function makeStateEmitter(onStateChange: (s: OrbState) => void) {
 export interface VapiAdapterOptions {
   /** Assistant ID passed to vapi.start() when the orb is clicked. */
   assistantId?: string
+  /** Return undefined to disable metering of the SDK-owned microphone track. */
+  createAudioContext?: AudioContextSource
+  /** Optional live-tunable input calibration overrides. */
+  inputVolumeCalibration?: VolumeCalibrationSource
   /** Optional live-tunable output calibration overrides. */
   outputVolumeCalibration?: VolumeCalibrationSource
+  /** Receives raw microphone RMS, mapped, and normalized input levels. */
+  onInputVolumeSample?: (sample: VolumeSample) => void
   /** Receives raw, mapped, and normalized output levels for diagnostics. */
   onOutputVolumeSample?: (sample: VolumeSample) => void
 }
 
 export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptions): OrbAdapter {
   const startListeners = new Set<() => void>()
+  const endListeners = new Set<() => void>()
   let originalStart: VapiClient['start'] | null = null
 
   function ensureStartIntercept() {
@@ -137,11 +154,16 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
     },
 
     stop() {
+      endListeners.forEach((listener) => listener())
       client.stop()
     },
 
     subscribe(listener: OrbSignalListener) {
-      let signal: OrbSignal = { state: 'idle', outputVolume: 0 }
+      let signal: OrbSignal = { state: 'idle', inputVolume: 0, outputVolume: 0 }
+      const inputNormalizer = createVolumeNormalizer(
+        PROVIDER_VOLUME_CALIBRATIONS.vapi.input,
+        options?.inputVolumeCalibration,
+      )
       const outputNormalizer = createVolumeNormalizer(
         PROVIDER_VOLUME_CALIBRATIONS.vapi.output,
         options?.outputVolumeCalibration,
@@ -170,18 +192,77 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
       // Track current state so we can gate volume sources
       let currentState: OrbState = 'idle'
       let callActive = false
+      let inputTrack: MediaStreamTrack | undefined
+      let inputMeter: MediaStreamTrackVolumeMeter | undefined
+      let inputPoll: ReturnType<typeof setInterval> | undefined
+
+      function clearInputTrack(emit = true) {
+        void inputMeter?.stop().catch(() => undefined)
+        inputMeter = undefined
+        inputTrack = undefined
+        inputNormalizer.reset()
+        if (emit && signal.inputVolume) emitPatch({ inputVolume: 0 })
+      }
+
+      function syncInputTrack() {
+        let track: MediaStreamTrack | undefined
+        try {
+          const audio = client.getDailyCallObject?.()?.participants().local?.tracks?.audio
+          if (!audio?.state || audio.state === 'playable') {
+            track = audio?.persistentTrack ?? audio?.track
+          }
+        } catch {
+          // Daily can be destroyed before Vapi emits call-end.
+        }
+        if (track?.readyState === 'ended' || track?.enabled === false || track?.muted)
+          track = undefined
+        if (track === inputTrack) return
+        clearInputTrack()
+        if (!track) return
+        inputTrack = track
+        const meteredTrack = track
+        inputMeter = createMediaStreamTrackVolumeMeter(
+          track,
+          options?.createAudioContext ??
+            (() => {
+              if (typeof window === 'undefined' || !window.AudioContext) return undefined
+              return new window.AudioContext()
+            }),
+          (raw) => {
+            if (!callActive || inputTrack !== meteredTrack) return
+            const sample = inputNormalizer.sample(
+              meteredTrack.enabled && !meteredTrack.muted && meteredTrack.readyState !== 'ended'
+                ? raw
+                : 0,
+            )
+            options?.onInputVolumeSample?.(sample)
+            emitPatch({ inputVolume: sample.normalized })
+          },
+        )
+      }
+
+      function stopInputMeter(emit = true) {
+        if (inputPoll !== undefined) clearInterval(inputPoll)
+        inputPoll = undefined
+        clearInputTrack(emit)
+      }
 
       const onCallStart = () => {
         callActive = true
         emitState('listening')
+        if (client.getDailyCallObject) {
+          syncInputTrack()
+          if (inputPoll === undefined) inputPoll = setInterval(syncInputTrack, 100)
+        }
       }
 
       const onCallEnd = () => {
         callActive = false
         currentState = 'idle'
+        stopInputMeter()
         stopVolLoop()
         emitState('idle')
-        emitPatch({ outputVolume: 0 })
+        emitPatch({ inputVolume: 0, outputVolume: 0 })
       }
 
       const onSpeechStart = () => {
@@ -252,8 +333,9 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
         callActive = false
         currentState = 'error'
         clearTimer()
+        stopInputMeter()
         stopVolLoop()
-        emitPatch({ state: 'error', outputVolume: 0, error })
+        emitPatch({ state: 'error', inputVolume: 0, outputVolume: 0, error })
       }
 
       client.on('call-start', onCallStart)
@@ -266,10 +348,13 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
 
       // Intercept vapi.start() to emit 'connecting' immediately
       startListeners.add(onStart)
+      endListeners.add(onCallEnd)
       ensureStartIntercept()
 
       return () => {
         clearTimer()
+        callActive = false
+        stopInputMeter(false)
         stopVolLoop()
         client.removeListener('call-start', onCallStart as () => void)
         client.removeListener('call-end', onCallEnd as () => void)
@@ -279,6 +364,7 @@ export function createVapiAdapter(client: VapiClient, options?: VapiAdapterOptio
         client.removeListener('message', onMessage as (...args: unknown[]) => void)
         client.removeListener('error', onError as (...args: unknown[]) => void)
         startListeners.delete(onStart)
+        endListeners.delete(onCallEnd)
         restoreStartInterceptIfUnused()
       }
     },

--- a/src/adapters/volume-presets.test.ts
+++ b/src/adapters/volume-presets.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { mapVolumeAmplitude } from './audio-level'
+import { PROVIDER_VOLUME_CALIBRATIONS } from './volume-presets'
+
+describe('provider volume calibrations', () => {
+  it('uses the shared speech anchors and envelope semantics in every direction', () => {
+    for (const directions of Object.values(PROVIDER_VOLUME_CALIBRATIONS)) {
+      for (const profile of Object.values(directions)) {
+        expect(profile.amplitude.silenceFloor).toBeLessThan(profile.amplitude.speechReference)
+        expect(profile.amplitude.speechReference).toBeLessThan(profile.amplitude.speechPeak)
+        expect(mapVolumeAmplitude(profile.amplitude.silenceFloor, profile.amplitude)).toBe(0)
+        expect(
+          mapVolumeAmplitude(profile.amplitude.speechReference, profile.amplitude),
+        ).toBeCloseTo(0.5)
+        expect(mapVolumeAmplitude(profile.amplitude.speechPeak, profile.amplitude)).toBe(1)
+        expect(profile.envelope).toEqual({ riseTimeMs: 100, fallTimeMs: 250 })
+      }
+    }
+  })
+})

--- a/src/adapters/volume-presets.test.ts
+++ b/src/adapters/volume-presets.test.ts
@@ -13,7 +13,7 @@ describe('provider volume calibrations', () => {
           mapVolumeAmplitude(profile.amplitude.speechReference, profile.amplitude),
         ).toBeCloseTo(0.5)
         expect(mapVolumeAmplitude(profile.amplitude.speechPeak, profile.amplitude)).toBe(1)
-        expect(profile.envelope).toEqual({ riseTimeMs: 100, fallTimeMs: 250 })
+        expect(profile.envelope).toEqual({ riseTimeMs: 100, fallTimeMs: 400 })
       }
     }
   })

--- a/src/adapters/volume-presets.test.ts
+++ b/src/adapters/volume-presets.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { mapVolumeAmplitude } from './audio-level'
+import { createVolumeNormalizer, mapVolumeAmplitude } from './audio-level'
 import { PROVIDER_VOLUME_CALIBRATIONS } from './volume-presets'
 
 describe('provider volume calibrations', () => {
+  it.each([
+    ['input', 0.35],
+    ['output', 0.39],
+  ] as const)(
+    'keeps ordinary ElevenLabs %s activity in the middle of the range',
+    (direction, raw) => {
+      // Rounded voiced medians measured with client 1.9.0 in real WebRTC sessions.
+      // Frequency-based SDK levels are substantially higher than waveform RMS.
+      const normalizer = createVolumeNormalizer(PROVIDER_VOLUME_CALIBRATIONS.elevenlabs[direction])
+      let normalized = 0
+      for (let time = 0; time <= 1000; time += 33) {
+        normalized = normalizer.sample(raw, time).normalized
+      }
+      expect(normalized).toBeGreaterThan(0.35)
+      expect(normalized).toBeLessThan(0.65)
+    },
+  )
+
   it('uses the shared speech anchors and envelope semantics in every direction', () => {
     for (const directions of Object.values(PROVIDER_VOLUME_CALIBRATIONS)) {
       for (const profile of Object.values(directions)) {

--- a/src/adapters/volume-presets.ts
+++ b/src/adapters/volume-presets.ts
@@ -1,0 +1,52 @@
+import type { VolumeCalibration } from './audio-level'
+
+export interface DirectionalVolumeCalibration {
+  input?: VolumeCalibration
+  output?: VolumeCalibration
+}
+
+const CANONICAL_ENVELOPE = {
+  riseTimeMs: 100,
+  fallTimeMs: 250,
+} as const
+
+function calibration(
+  silenceFloor: number,
+  speechReference: number,
+  speechPeak: number,
+): VolumeCalibration {
+  return {
+    amplitude: { silenceFloor, speechReference, speechPeak },
+    envelope: { ...CANONICAL_ENVELOPE },
+  }
+}
+
+/**
+ * Shipped provider baselines. The playground calibration runner generates
+ * replacements from guided raw-level captures without requiring manual sliders.
+ */
+export const PROVIDER_VOLUME_CALIBRATIONS = {
+  vapi: {
+    output: calibration(0.12, 0.667, 1),
+  },
+  elevenlabs: {
+    input: calibration(0, 0.25, 0.5),
+    output: calibration(0, 0.25, 0.5),
+  },
+  livekit: {
+    input: calibration(0, 0.293_365, 0.5),
+    output: calibration(0.015, 0.133_981, 0.232_391),
+  },
+  pipecat: {
+    input: calibration(0.002, 0.107_112, 0.252),
+    output: calibration(0.002, 0.084_441, 0.198_078),
+  },
+  openai: {
+    input: calibration(0, 0.105_112, 0.25),
+    output: calibration(0.003, 0.108_112, 0.253),
+  },
+  gemini: {
+    input: calibration(0, 0.105_112, 0.25),
+    output: calibration(0.003, 0.108_112, 0.253),
+  },
+} as const satisfies Record<string, DirectionalVolumeCalibration>

--- a/src/adapters/volume-presets.ts
+++ b/src/adapters/volume-presets.ts
@@ -7,7 +7,7 @@ export interface DirectionalVolumeCalibration {
 
 const CANONICAL_ENVELOPE = {
   riseTimeMs: 100,
-  fallTimeMs: 250,
+  fallTimeMs: 400,
 } as const
 
 function calibration(
@@ -34,7 +34,7 @@ export const PROVIDER_VOLUME_CALIBRATIONS = {
     output: calibration(0, 0.25, 0.5),
   },
   livekit: {
-    input: calibration(0, 0.293_365, 0.5),
+    input: calibration(0, 0.18, 0.4),
     output: calibration(0.015, 0.133_981, 0.232_391),
   },
   pipecat: {

--- a/src/adapters/volume-presets.ts
+++ b/src/adapters/volume-presets.ts
@@ -27,7 +27,8 @@ function calibration(
  */
 export const PROVIDER_VOLUME_CALIBRATIONS = {
   vapi: {
-    output: calibration(0.12, 0.667, 1),
+    input: calibration(0, 0.105_112, 0.25),
+    output: calibration(0.005, 0.4, 1),
   },
   elevenlabs: {
     input: calibration(0, 0.36, 0.52),

--- a/src/adapters/volume-presets.ts
+++ b/src/adapters/volume-presets.ts
@@ -47,6 +47,6 @@ export const PROVIDER_VOLUME_CALIBRATIONS = {
   },
   gemini: {
     input: calibration(0, 0.105_112, 0.25),
-    output: calibration(0.003, 0.108_112, 0.253),
+    output: calibration(0.003, 0.17, 0.38),
   },
 } as const satisfies Record<string, DirectionalVolumeCalibration>

--- a/src/adapters/volume-presets.ts
+++ b/src/adapters/volume-presets.ts
@@ -30,12 +30,12 @@ export const PROVIDER_VOLUME_CALIBRATIONS = {
     output: calibration(0.12, 0.667, 1),
   },
   elevenlabs: {
-    input: calibration(0, 0.25, 0.5),
-    output: calibration(0, 0.25, 0.5),
+    input: calibration(0, 0.36, 0.52),
+    output: calibration(0, 0.4, 0.55),
   },
   livekit: {
     input: calibration(0, 0.18, 0.4),
-    output: calibration(0.015, 0.133_981, 0.232_391),
+    output: calibration(0.015, 0.18, 0.3),
   },
   pipecat: {
     input: calibration(0.002, 0.107_112, 0.252),

--- a/src/adapters/volume-presets.ts
+++ b/src/adapters/volume-presets.ts
@@ -44,7 +44,7 @@ export const PROVIDER_VOLUME_CALIBRATIONS = {
   },
   openai: {
     input: calibration(0, 0.105_112, 0.25),
-    output: calibration(0.003, 0.108_112, 0.253),
+    output: calibration(0.003, 0.07, 0.2),
   },
   gemini: {
     input: calibration(0, 0.105_112, 0.25),

--- a/src/components/Orb/Orb.test.tsx
+++ b/src/components/Orb/Orb.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import { Orb } from './Orb'
-import { deriveOrbState, deriveOrbVolume } from './signals'
+import { deriveOrbState, selectOrbVolume } from './signals'
 import type { OrbAdapter, OrbSignal } from './Orb.types'
 
 function createAdapter(): OrbAdapter {
@@ -136,9 +136,12 @@ describe('Orb accessibility', () => {
     expect(html).toContain('0.72')
   })
 
-  it('lets scalar controlled props override signal values', () => {
+  it('selects the volume channel for an overridden controlled state', () => {
     const html = renderToStaticMarkup(
-      <Orb signal={{ state: 'speaking', outputVolume: 0.72 }} state="listening" volume={0.4} />,
+      <Orb
+        signal={{ state: 'speaking', inputVolume: 0.4, outputVolume: 0.72 }}
+        state="listening"
+      />,
     )
 
     expect(html).toContain('listening')
@@ -155,15 +158,13 @@ describe('Orb accessibility', () => {
 })
 
 describe('Orb signal helpers', () => {
-  it('derives state and volume with controlled prop precedence', () => {
+  it('derives state and selects the matching directional volume', () => {
     const adapterSignal: OrbSignal = { state: 'speaking', outputVolume: 0.9 }
 
     expect(deriveOrbState(undefined, undefined, adapterSignal)).toBe('speaking')
     expect(deriveOrbState('listening', { state: 'speaking' }, adapterSignal)).toBe('listening')
-    expect(deriveOrbVolume(undefined, 'speaking', adapterSignal)).toBe(0.9)
-    expect(deriveOrbVolume(undefined, 'listening', { state: 'listening', inputVolume: 0.3 })).toBe(
-      0.3,
-    )
-    expect(deriveOrbVolume(0.4, 'speaking', adapterSignal)).toBe(0.4)
+    expect(selectOrbVolume('speaking', adapterSignal)).toBe(0.9)
+    expect(selectOrbVolume('listening', { state: 'listening', inputVolume: 0.3 })).toBe(0.3)
+    expect(selectOrbVolume('thinking', adapterSignal)).toBe(0)
   })
 })

--- a/src/components/Orb/Orb.tsx
+++ b/src/components/Orb/Orb.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { OrbProps, OrbSignal } from './Orb.types'
-import { deriveOrbState, deriveOrbVolume } from './signals'
+import { deriveOrbState, selectOrbVolume } from './signals'
 import { DebugTheme } from '../../themes/debug'
 import { CircleTheme } from '../../themes/circle'
 import { BarsTheme } from '../../themes/bars'
@@ -10,7 +10,6 @@ import { RadialTheme } from '../../themes/radial'
 export function Orb({
   signal: signalProp,
   state: stateProp,
-  volume: volumeProp,
   adapter,
   theme = 'debug',
   size = 200,
@@ -34,7 +33,7 @@ export function Orb({
 
   const activeSignal = signalProp ?? adapterSignal
   const state = deriveOrbState(stateProp, signalProp, adapterSignal)
-  const volume = deriveOrbVolume(volumeProp, state, activeSignal)
+  const volume = selectOrbVolume(state, activeSignal)
 
   const isActive = state !== 'idle' && state !== 'error'
 

--- a/src/components/Orb/Orb.types.ts
+++ b/src/components/Orb/Orb.types.ts
@@ -11,7 +11,6 @@ export type OrbTheme = 'debug' | 'circle' | 'bars' | 'cloud' | 'radial'
 
 export interface OrbSignal {
   state: OrbState
-  volume?: number
   inputVolume?: number
   outputVolume?: number
   error?: unknown
@@ -60,12 +59,6 @@ export interface OrbProps extends OrbHtmlAttributes {
    * Overrides signal and adapter state if provided.
    */
   state?: OrbState
-
-  /**
-   * Current audio volume, normalized 0–1.
-   * Overrides signal and adapter volume if provided.
-   */
-  volume?: number
 
   /**
    * Provider adapter (Vapi, ElevenLabs, etc.).

--- a/src/components/Orb/signals.ts
+++ b/src/components/Orb/signals.ts
@@ -8,9 +8,8 @@ export function deriveOrbState(
   return state ?? signal?.state ?? adapterSignal.state
 }
 
-export function deriveOrbVolume(volume: number | undefined, state: OrbState, signal: OrbSignal) {
-  if (volume !== undefined) return volume
-  if (state === 'listening') return signal.inputVolume ?? signal.volume ?? 0
-  if (state === 'speaking') return signal.outputVolume ?? signal.volume ?? 0
-  return signal.volume ?? 0
+export function selectOrbVolume(state: OrbState, signal: OrbSignal) {
+  if (state === 'listening') return signal.inputVolume ?? 0
+  if (state === 'speaking') return signal.outputVolume ?? 0
+  return 0
 }

--- a/tests/e2e/fixture/main.tsx
+++ b/tests/e2e/fixture/main.tsx
@@ -7,7 +7,6 @@ import { createLiveKitAdapter as createManagedLiveKitAdapter } from 'orb-ui/adap
 
 const IDLE_SIGNAL: OrbSignal = {
   state: 'idle',
-  volume: 0,
   inputVolume: 0,
   outputVolume: 0,
 }
@@ -29,7 +28,7 @@ function App() {
         return () => listeners.delete(listener)
       },
       start() {
-        emit({ state: 'listening', volume: 0.42, inputVolume: 0.42, outputVolume: 0 })
+        emit({ state: 'listening', inputVolume: 0.42, outputVolume: 0 })
       },
       stop() {
         emit(IDLE_SIGNAL)

--- a/tests/package-typecheck/package-consumer.tsx
+++ b/tests/package-typecheck/package-consumer.tsx
@@ -69,7 +69,7 @@ const advancedLiveKitAdapter = createAdvancedLiveKitAdapter(liveKitConfig)
 const liveKitBrowserConfig: LiveKitBrowserAdapterConfig = {
   tokenEndpoint: '/api/livekit-token',
   agentName: 'support-agent',
-  outputVolumeCalibration: { attack: 0.3 },
+  outputVolumeCalibration: { envelope: { riseTimeMs: 300 } },
 }
 const liveKitAdapter = createLiveKitAdapter(liveKitBrowserConfig)
 
@@ -80,7 +80,7 @@ const pipecatClient: PipecatClientLike = {
   disconnect: async () => undefined,
 }
 const pipecatAdapter = createPipecatAdapter(pipecatClient, {
-  outputVolumeCalibration: { release: 0.2 },
+  outputVolumeCalibration: { envelope: { fallTimeMs: 200 } },
 })
 
 const openAIRealtimeAdapter = createOpenAIRealtimeAdapter({

--- a/tests/typecheck/provider-adapters.tsx
+++ b/tests/typecheck/provider-adapters.tsx
@@ -38,7 +38,7 @@ const tokenElevenLabsAdapter = createElevenLabsAdapter(Conversation, {
 const liveKitAdapter = createLiveKitAdapter({
   tokenEndpoint: '/api/livekit-token',
   agentName: 'support-agent',
-  outputVolumeCalibration: { release: 0.12 },
+  outputVolumeCalibration: { envelope: { fallTimeMs: 120 } },
   onOutputVolumeSample: ({ normalized }) => void normalized,
 })
 
@@ -58,7 +58,7 @@ const pipecatClient = new PipecatClient({
 })
 const pipecatAdapter = createPipecatAdapter(pipecatClient, {
   connect: () => pipecatClient.connect({ webrtcUrl: 'https://agent.example.com/api/offer' }),
-  outputVolumeCalibration: () => ({ gain: 3.5 }),
+  outputVolumeCalibration: () => ({ amplitude: { speechPeak: 0.35 } }),
   onOutputVolumeSample: ({ raw }) => void raw,
 })
 
@@ -166,7 +166,7 @@ export function ProviderAdapterSmokeExamples() {
       <Orb signal={signal} theme="circle" />
       <Orb signal={{ state: 'listening', inputVolume: 0.45 }} theme="radial" />
       <Orb adapter={customSignalAdapter} interactive={false} theme="cloud" />
-      <Orb state="listening" volume={0.4} theme="debug" id="controlled-orb" />
+      <Orb signal={{ state: 'listening', inputVolume: 0.4 }} theme="debug" id="controlled-orb" />
     </>
   )
 }


### PR DESCRIPTION
## Summary

Standardize adapters on separate input/output calibration profiles and a stable semantic speech envelope. Remove the ambiguous `volume` prop and `OrbSignal.volume`; controlled and custom integrations migrate to `inputVolume` while listening and `outputVolume` while speaking. Includes a minor changeset, migration docs, raw/mapped/normalized diagnostics, and guided playground calibration.

The contract targets silence at 0, ordinary speech around 0.5, and uncommon strong peaks near 1, with 100ms rise / 400ms fall. Available directional envelopes remain warm across active states and reset on stop, connection, or error.

## Live QA fixes

- Retune ElevenLabs input/output and LiveKit output from live SDK measurements. On the same recorded trace, ElevenLabs normal-input median moves from 0.700 to 0.477 and voiced-output median from 0.804 to 0.509; LiveKit output moves from 0.687 to 0.471. An independent live test with another voice/phrase gives input/output medians of 0.563/0.584 for ElevenLabs and 0.569/0.460 for LiveKit. Keep LiveKit input and Pipecat profiles unchanged.
- Preserve Pipecat `speaking` when overlapping LLM/TTS generation starts. Generation previously replaced speech-reactive animation with `thinking` while audio was audible in two recordings. Playback retains priority; user speech can still interrupt it. Two regressions cover both generation events and interruption. A fresh live session produced 889 voiced-output frames, all in `speaking`, with normal-input/output medians 0.568/0.463. That session did not repeat the overlapping-event ordering; regression tests cover it directly.
- Retune Gemini output from live measurements: original voiced-output median 0.747 becomes 0.529 on identical-trace replay, then 0.536 in independent live validation. The final complete run measured normal-input/output medians 0.577/0.512 with zero output saturation. Give detected user speech priority over buffered Gemini output state events to prevent listening/speaking flicker during interruption; regression coverage includes the next assistant turn.
- Add Vapi microphone metering from the SDK-owned local track, with no second microphone capture. Follow delayed tracks, replacement, mute, stop, error, and unsubscribe; keep event-only clients compatible. Add input diagnostics and playground calibration controls. Vapi output was understated (voiced median 0.261); revised anchors give 0.522 on the same trace, 0.529 in independent live validation, and 0.499 on the current SDK. Normal microphone input measures 0.578. Update demo and compatibility checks to Vapi 2.7.0 / Daily 0.87, removing the deprecated runtime warning. The final run completed all three turns: 752 voiced microphone frames were listening, and 642 of 645 voiced remote frames were speaking (three brief transition frames).
- Stabilize OpenAI Realtime state around WebRTC playback start/stop/clear events. Meter silence before the first packet and fading envelopes after playback previously caused listening/speaking flicker. Playback events now take priority, user speech keeps listening priority, and integrations without playback events retain meter fallback. Retune assistant output: baseline voiced median 0.354 becomes 0.496 on the same trace and 0.486 in a second-voice live test. Normal input stays 0.568. All three validation replies completed; all 766 voiced microphone frames were listening and all 698 voiced remote frames were speaking, with zero output saturation. Two regression tests cover packet delay, tails, interruption, clear, restart, and fallback.
- Correct ElevenLabs metric documentation: its SDK measures frequency-band activity, not waveform RMS.

## Method and verification

Real Vapi, ElevenLabs, LiveKit, Pipecat, OpenAI Realtime, and Gemini sessions used the same prerecorded quiet/normal/loud microphone sequence, independent waveform meters, and raw/mapped/normalized traces. Browser echo cancellation, noise suppression, and automatic gain control stayed enabled. Another voice and phrase validated the proposed profiles. Physical microphones and room acoustics remain variable.

Full `pnpm check` passes: formatting, lint, source/example/package/demo typechecks, 53 unit tests, package/demo builds, and 4 browser tests. Four-theme review videos replay measured live signals with captured input/output audio on a deterministic frame clock.

All six providers now have measured live input/output evidence and four-theme review videos. OpenAI's 27.7-second review includes startup, ordinary microphone speech, thinking, a complete assistant reply, and stop. The videos replay recorded live signals with synchronized captured audio; they do not establish physical microphone or room-acoustic coverage. Final visual acceptance remains before release.

One Gemini run did not answer its late energetic turn before the 101-second stop; the next diagnostic run completed all three responses, with all 805 voiced-output frames in speaking state. The isolated stall's cause is not established.

## Review and release order

Keep #39 stacked on this PR. Review the completed provider videos, then merge this PR first and verify #39's remaining diff before retargeting. Release both together as 0.8.0 from 0.7.0.

Agent: Codex (GPT-6), tasked with reviewing both PRs, measuring live provider input/output, recording animations, and fixing reproducible issues.