### PR TITLE
docs: strengthen voice agent guide internal links

### DIFF
--- a/docs/adapters/custom.mdx
+++ b/docs/adapters/custom.mdx
@@ -164,4 +164,5 @@ The orb can only reflect lifecycle accuracy if the underlying runtime actually r
 
 For an end-to-end example, see the [voice orb UI example](/examples/voice-orb-ui). If your provider
 already has a first-party adapter, compare this setup with the [adapter overview](/adapters/overview)
-before maintaining a custom wrapper.
+before maintaining a custom wrapper. Use the [React voice agent UI guide](/guides/voice-agent-ui)
+for the interaction states, accessibility, and recovery patterns that sit above either approach.

--- a/docs/adapters/elevenlabs.mdx
+++ b/docs/adapters/elevenlabs.mdx
@@ -140,6 +140,7 @@ adapter before replacing it.
 
 ## Related
 
+- [React voice agent UI guide](/guides/voice-agent-ui)
 - [Adapter overview](/adapters/overview)
 - [Voice orb UI example](/examples/voice-orb-ui)
 - [Custom integrations](/adapters/custom)

--- a/docs/adapters/gemini-live.mdx
+++ b/docs/adapters/gemini-live.mdx
@@ -139,5 +139,5 @@ ephemeral Live authentication remains on that endpoint.
 ## Related
 
 - [Custom integrations](/adapters/custom)
-- [Voice agent UI guide](/guides/voice-agent-ui)
+- [React voice agent UI lifecycle guide](/guides/voice-agent-ui)
 - [Gemini Live ephemeral tokens](https://ai.google.dev/gemini-api/docs/live-api/ephemeral-tokens)

--- a/docs/adapters/livekit.mdx
+++ b/docs/adapters/livekit.mdx
@@ -185,3 +185,9 @@ If your app already normalizes LiveKit state and volume, pass those values direc
 ```tsx
 <Orb signal={{ state: voiceState, inputVolume, outputVolume }} theme="circle" />
 ```
+
+## Related
+
+- [Voice agent interface design guide](/guides/voice-agent-ui)
+- [Adapter overview](/adapters/overview)
+- [Themes and voice states](/themes/voice-states)

--- a/docs/adapters/openai-realtime.mdx
+++ b/docs/adapters/openai-realtime.mdx
@@ -142,5 +142,5 @@ silence rather than tuning to a single loud clip.
 ## Related
 
 - [Custom integrations](/adapters/custom)
-- [Voice agent UI guide](/guides/voice-agent-ui)
+- [React voice agent UI lifecycle guide](/guides/voice-agent-ui)
 - [OpenAI Realtime WebRTC guide](https://developers.openai.com/api/docs/guides/realtime-webrtc)

--- a/docs/adapters/overview.mdx
+++ b/docs/adapters/overview.mdx
@@ -123,6 +123,10 @@ audio calibration hooks. Those options are escape hatches. Start with the first 
 guide and add advanced configuration only when your application already owns that part of the
 provider lifecycle.
 
+Before choosing a provider, use the [React voice agent UI guide](/guides/voice-agent-ui) to plan
+the listening, thinking, speaking, error, accessibility, and recovery behavior shared by every
+integration.
+
 - [Vapi](/adapters/vapi)
 - [ElevenLabs](/adapters/elevenlabs)
 - [LiveKit](/adapters/livekit)

--- a/docs/adapters/pipecat.mdx
+++ b/docs/adapters/pipecat.mdx
@@ -130,6 +130,7 @@ parameters. `disconnect` defaults to `client.disconnect()` and can also be overr
 
 ## Related
 
+- [Building a React voice agent UI](/guides/voice-agent-ui)
 - [LiveKit adapter](/adapters/livekit)
 - [Custom integrations](/adapters/custom)
 - [Pipecat JavaScript client](https://docs.pipecat.ai/api-reference/client/js/overview)

--- a/docs/adapters/vapi.mdx
+++ b/docs/adapters/vapi.mdx
@@ -133,4 +133,4 @@ orb-ui is not a Vapi replacement. It is a frontend UI layer for teams already bu
 - [Adapter overview](/adapters/overview)
 - [Voice orb UI example](/examples/voice-orb-ui)
 - [Custom integrations](/adapters/custom)
-- [Voice agent UI guide](/guides/voice-agent-ui)
+- [Designing a React voice agent UI](/guides/voice-agent-ui)

--- a/docs/examples/voice-orb-ui.mdx
+++ b/docs/examples/voice-orb-ui.mdx
@@ -165,6 +165,7 @@ set `interactive={false}` and label those controls instead.
 - Keep error states obvious but not alarming.
 - Pair the orb with a transcript or status label when users need more precision.
 
-Continue with the [themes and voice states reference](/themes/voice-states), choose a provider in the
-[adapter overview](/adapters/overview), or connect an app-owned runtime with the
-[custom integration guide](/adapters/custom).
+Use the [complete voice agent UI guide](/guides/voice-agent-ui) to plan the production lifecycle.
+Then continue with the [themes and voice states reference](/themes/voice-states), choose a provider
+in the [adapter overview](/adapters/overview), or connect an app-owned runtime with the [custom
+integration guide](/adapters/custom).

--- a/docs/guides/ai-voice-sales-agents.mdx
+++ b/docs/guides/ai-voice-sales-agents.mdx
@@ -121,7 +121,7 @@ already has a call-state layer. Start with the [adapter overview](/adapters/over
 
 ## Related
 
-- [Voice agent UI guide](/guides/voice-agent-ui)
+- [React voice agent UI design guide](/guides/voice-agent-ui)
 - [Voice agent platforms guide](/guides/voice-agent-platforms)
 - [Voice orb UI example](/examples/voice-orb-ui)
 - [Themes and voice states](/themes/voice-states)

--- a/docs/guides/voice-ai-customer-support.mdx
+++ b/docs/guides/voice-ai-customer-support.mdx
@@ -116,7 +116,7 @@ its normalized signal into controlled mode.
 
 ## Related
 
-- [Voice agent UI guide](/guides/voice-agent-ui)
+- [React voice agent UI design guide](/guides/voice-agent-ui)
 - [Voice agent platforms guide](/guides/voice-agent-platforms)
 - [Voice orb UI example](/examples/voice-orb-ui)
 - [Themes and voice states](/themes/voice-states)

--- a/docs/themes/voice-states.mdx
+++ b/docs/themes/voice-states.mdx
@@ -117,4 +117,4 @@ and error recovery remain usable when motion is reduced or the canvas is unavail
 - Keyboard focus and labels are clear for interactive variants.
 
 See the [voice orb UI example](/examples/voice-orb-ui) for controlled and provider-backed patterns,
-or the [voice agent UI guide](/guides/voice-agent-ui) for the complete lifecycle design.
+or the [React voice agent UI guide](/guides/voice-agent-ui) for the complete lifecycle design.


### PR DESCRIPTION
## Summary

- add a contextual link to the core React voice agent UI guide from the adapter overview
- add missing guide links to the ElevenLabs, LiveKit, Pipecat, custom-integration, and voice-orb example pages
- refine existing anchor text across provider, theme, sales, and customer-support docs so links describe the guide's purpose

## Why

The July 16–19 Search Console review showed strong early discovery on adapter and new content pages, while the core `/docs/guides/voice-agent-ui` page improved in average position but lost impressions and clicks. This pass uses relevant pages that are already gaining visibility to make the guide easier for readers and crawlers to discover without changing titles, metadata, or page structure.

## Impact

Documentation and internal navigation only. There are no runtime, package, API, or release-note changes.

## Validation

- `git diff --check`
- `pnpm check` stages passed: formatting, lint, type checks, 42 unit tests, library build, package checks, demo typecheck, and demo build
- `pnpm test:e2e:built`: 4 browser tests passed after rerunning outside the sandbox because its local port binding was restricted

## Roadmap

No roadmap update: this is a focused SEO and documentation-navigation improvement rather than product roadmap progress.

## Agent context

Authored by Codex from a request to strengthen internal linking to the core voice agent UI guide after reviewing Google Search Console performance.