### PR TITLE
docs: strengthen voice agent search intent

### DIFF
--- a/docs/adapters/elevenlabs.mdx
+++ b/docs/adapters/elevenlabs.mdx
@@ -1,9 +1,11 @@
 ---
-title: ElevenLabs Voice UI for React
-description: Add an ElevenLabs voice UI to React with orb-ui's adapter, audio-reactive themes, and controlled voice agent states.
+title: ElevenLabs Voice Orb UI for React
+description: Build an ElevenLabs Conversational AI voice orb UI in React with provider state mapping, audio-reactive themes, and accessible controls.
 ---
 
-ElevenLabs can power conversational voice experiences. orb-ui gives those experiences a visible React UI layer: an animated orb, audio-reactive feedback, and predictable voice states.
+ElevenLabs Conversational AI can power realtime voice experiences. orb-ui turns those sessions into
+a React voice orb UI with visible listening and speaking states, audio-reactive feedback, and
+accessible call controls.
 
 ## Install
 
@@ -54,7 +56,7 @@ Create the adapter with a fresh credential when that credential is single-use or
 application remains responsible for authenticating and rate-limiting the server endpoint that
 mints it.
 
-## State mapping
+## ElevenLabs voice orb state mapping
 
 The ElevenLabs adapter is responsible for normalizing provider events into orb-ui states. Keep the UI language simple:
 

--- a/docs/examples/voice-orb-ui.mdx
+++ b/docs/examples/voice-orb-ui.mdx
@@ -1,9 +1,16 @@
 ---
 title: Voice Orb UI Example for React
-description: Build a React voice orb UI with animated states, audio-reactive motion, adapters, and controlled mode.
+description: Build an animated React voice orb UI with lifecycle states, audio-reactive motion, provider adapters, accessible controls, and custom signals.
 ---
 
-The orb is the visible state layer for a voice agent. It should communicate activity quickly and stay out of the way while a user is talking.
+A React voice orb is the visible state layer for a voice agent. It should make listening, thinking,
+speaking, and error states understandable at a glance while staying out of the way of the
+conversation.
+
+## Build an animated voice orb in React
+
+Start with a controlled `Orb` when you want to preview the component before connecting a live
+voice provider:
 
 ```tsx
 import { Orb } from 'orb-ui'
@@ -13,9 +20,9 @@ export function VoiceOrbExample() {
 }
 ```
 
-For a production voice experience, drive the state and volume from a real session. A fixed value is
-useful for previews and visual tests, but it should not be used to imply that the microphone or
-assistant is active.
+This renders an animated voice orb in its listening state. For a production voice experience,
+drive the state and volume from a real session. A fixed value is useful for previews and visual
+tests, but it should not be used to imply that the microphone or assistant is active.
 
 ## Simulate the full lifecycle
 

--- a/docs/guides/voice-agent-ui.mdx
+++ b/docs/guides/voice-agent-ui.mdx
@@ -1,11 +1,52 @@
 ---
 title: Voice Agent UI Components for React
-description: Design React voice agent UI components that communicate listening, speaking, connecting, and error states clearly.
+description: Build a React voice agent UI with animated orbs, lifecycle states, provider adapters, accessible controls, and production-ready patterns.
 ---
 
-A voice agent needs more than a microphone button. Users need to know when the agent is connecting, listening, thinking, speaking, or failing. orb-ui gives React teams a small UI layer for those moments: animated voice orbs, audio-reactive themes, provider adapters, and controlled mode.
+A React voice agent UI is the visual and interactive layer that shows what a realtime voice
+assistant is doing. It should make connecting, listening, thinking, speaking, interruption, and
+failure understandable without forcing users to interpret an animation on its own.
 
-## What the UI has to communicate
+orb-ui gives React teams that layer through animated voice orbs, audio-reactive themes, provider
+adapters, and controlled state. Use it with Vapi, ElevenLabs, LiveKit, Pipecat, OpenAI Realtime,
+Gemini Live, or a custom browser voice stack.
+
+## Build a React voice agent UI
+
+Install the component package:
+
+```bash
+npm install orb-ui
+```
+
+Start in controlled mode when your application already owns the voice session state:
+
+```tsx
+import { Orb, type OrbState } from 'orb-ui'
+
+type VoiceAgentUIProps = {
+  state: OrbState
+  volume: number
+}
+
+export function VoiceAgentUI({ state, volume }: VoiceAgentUIProps) {
+  return (
+    <Orb
+      state={state}
+      volume={volume}
+      theme="circle"
+      size={240}
+      aria-label={`Voice assistant is ${state}`}
+    />
+  )
+}
+```
+
+For a provider-backed experience, connect an orb-ui adapter so the provider session drives the
+visual state and audio levels. The [adapter comparison](/adapters/overview) explains which
+integration owns authentication, media, playback, state mapping, and cleanup.
+
+## What a voice agent UI has to communicate
 
 The important job of a voice agent UI is trust. A user should understand whether the app heard them, whether the assistant is waiting, and whether the assistant is speaking. The visual state should change quickly enough to feel alive, but it should not distract from the conversation.
 
@@ -50,7 +91,7 @@ Do not treat a click as proof that a voice session started. Provider authenticat
 permission, WebRTC negotiation, or device selection can still fail. The visible state should follow
 the session, not the optimistic button press.
 
-## Component architecture
+## React voice agent UI architecture
 
 Use an adapter when a provider can supply a normalized voice signal for you. Use controlled mode when your app already owns the voice session lifecycle.
 
@@ -58,14 +99,6 @@ For the complete `OrbSignal` and `OrbAdapter` contract, separate input/output me
 adapter example, read the [signal-based voice agent UI guide](/guides/signal-based-voice-agent-ui).
 
 Controlled mode is especially useful for teams experimenting with OpenAI Realtime, Gemini Live API, telephony backends, or internal speech pipelines.
-
-```tsx
-import { Orb } from 'orb-ui'
-
-export function VoiceAgentStatus({ state, volume }) {
-  return <Orb state={state} volume={volume} theme="circle" size={240} />
-}
-```
 
 Use `OrbSignal` when the browser can measure the user and agent independently:
 
@@ -146,7 +179,7 @@ evaluating a polished theme.
 | Integration     | Start with                                                      | Why                                                                     |
 | --------------- | --------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Vapi            | [Vapi Voice UI for React](/adapters/vapi)                       | Wrap an existing Vapi browser client and assistant                      |
-| ElevenLabs      | [ElevenLabs Voice UI for React](/adapters/elevenlabs)           | Let the adapter manage the conversational session and both audio levels |
+| ElevenLabs      | [ElevenLabs Voice Orb UI for React](/adapters/elevenlabs)       | Let the adapter manage the conversational session and both audio levels |
 | LiveKit Agents  | [LiveKit Voice UI for React](/adapters/livekit)                 | Connect through a token endpoint and map agent participant state        |
 | Pipecat         | [Pipecat Voice UI for React](/adapters/pipecat)                 | Reuse a configured Pipecat client across supported transports           |
 | OpenAI Realtime | [OpenAI Realtime Voice UI for React](/adapters/openai-realtime) | Let orb-ui own browser WebRTC and audio playback                        |
@@ -170,7 +203,7 @@ The UI should make the voice agent feel present without pretending to be the voi
 itself. A useful adoption page also includes the failure path: microphone requirements, credential
 boundaries, cleanup behavior, and what developers should expect after pressing start.
 
-## Production checklist
+## React voice agent UI production checklist
 
 Before shipping a React voice agent UI, verify that:
 

--- a/docs/themes/voice-states.mdx
+++ b/docs/themes/voice-states.mdx
@@ -1,9 +1,11 @@
 ---
-title: Voice orb themes and states
-description: Reference for orb-ui themes and voice agent states.
+title: Voice Orb Themes and States for React
+description: Choose accessible React voice orb themes for idle, connecting, listening, thinking, speaking, and error states.
 ---
 
-orb-ui ships with a small set of themes for common voice agent UI needs.
+orb-ui ships with React voice orb themes for common voice agent UI roles. Each theme maps the same
+session states into a different visual treatment, so teams can change the presentation without
+rewriting provider or audio logic.
 
 ## Choose a theme by interaction role
 


### PR DESCRIPTION
## Summary

- lead the React voice agent UI guide with a direct definition, install command, and usable controlled-mode example
- clarify lifecycle and architecture headings while keeping the guide URL and title stable
- give the voice-orb example, themes reference, and ElevenLabs guide distinct orb/theme/provider search intent
- align the ElevenLabs link label with its updated page title

## Why

The post-launch SEO review indicated that the core guide needed to satisfy implementation intent sooner, while narrower voice-orb and provider searches should land on more specific supporting pages. This keeps the pages complementary instead of making the main guide chase every adjacent query.

## Impact

Developers now get an install-and-build path before the longer production guidance. No runtime behavior, public API, sitemap route, or canonical URL changes.

No changeset is needed for documentation-only copy changes. ROADMAP.md is unchanged because this does not alter product direction or complete a roadmap item.

## Verification

- Prettier and `git diff --check`
- ESLint
- source, examples, package, demo, and E2E TypeScript checks
- 42 unit tests passed
- package and demo production builds passed
- 4 Playwright end-to-end tests passed (the browser stage was rerun with local-port permission after the sandbox blocked binding to `127.0.0.1:4173`)
