### PR TITLE
docs: correct 0.8.0 migration link anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   `PROVIDER_VOLUME_CALIBRATIONS` for provider-specific defaults. Diagnostic `shaped` is now `mapped`.
 
 See the [component migration guide](https://orb-ui.com/docs/reference/orb-component#migrating-from-volume)
-and [adapter migration guide](https://orb-ui.com/docs/adapters/overview#migrating-calibration-overrides-in-080).
+and [adapter migration guide](https://orb-ui.com/docs/adapters/overview#migrating-calibration-overrides-in-0-8-0).
 
 ### Minor Changes
 


### PR DESCRIPTION
Correct the 0.8.0 changelog's calibration migration link to the section ID rendered by the live documentation site: `migrating-calibration-overrides-in-0-8-0`.

Verified the target page returns HTTP 200 and contains that exact ID. Prettier and `git diff --check` pass. This changes one documentation link; no package version or runtime behavior changes, so no changeset or roadmap update is needed.

Agent: Codex (GPT-6), completing the approved 0.8.0 release.